### PR TITLE
Minimize git cache size

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -24,7 +24,7 @@ jobs:
         path: ~/.cache
         # The cache is reset on the first build of every week this way.
         # Change the -1 part if you need to force reset the cache
-        key: "${{ steps.current-time.outputs.formattedTime }}-1"
+        key: "${{ steps.current-time.outputs.formattedTime }}-2"
     - uses: actions/checkout@v3
       name: Clone self repository
       with:

--- a/update.rb
+++ b/update.rb
@@ -19,11 +19,13 @@ OPTIONAL_PRODUCT = ARGV[3]
 DEFAULT_VERSION_REGEX = '^v?(?<major>[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.?(?<patch>0|[1-9]\d*)?$'
 DEFAULT_TAG_TEMPLATE = "{{major}}{% if minor %}.{{minor}}{% if patch %}.{{patch}}{%endif%}{%endif%}"
 
+# extensions.partialClone=true is also set up in the workflow.
+# See also https://stackoverflow.com/a/65746233/374236
 def fetch_git_releases(repo_dir, config)
   pwd = Dir.pwd
   `git init --bare #{repo_dir}` unless Dir.exist? repo_dir
   Dir.chdir repo_dir
-  `git fetch --quiet --tags --filter=blob:none "#{config['git']}"`
+  `git fetch --quiet --tags --filter=blob:none --depth=1 "#{config['git']}"`
   Dir.chdir pwd
 end
 
@@ -158,7 +160,7 @@ Dir.glob("#{WEBSITE_DIR}/products/*.md").each do |product_file|
     data['auto'].each_with_index do |config, i|
       release_data.merge! get_releases(product, config, i)
     end
-     
+
     File.open(get_output_file(product), 'w') do |file|
       file.write(JSON.pretty_generate(release_data))
     end unless release_data.empty?


### PR DESCRIPTION
Add `--depth=1` to the git fetch command to minimize the git repositories size.

A test showed that this reduced the cache size from 7507 MB to 962 MB.