### PR TITLE
[java] fix script

### DIFF
--- a/src/java.py
+++ b/src/java.py
@@ -41,7 +41,9 @@ def main():
     print(f"::group::{PRODUCT}")
     releases = {}
     fetch_releases(releases)
-    releases.pop('1.0_alpha') # that's the only version we do not want, regex not needed
+    # that's the only version we do not want, regex not needed
+    if '1.0_alpha' in releases:
+        releases.pop('1.0_alpha')
     print("::endgroup::")
 
     with open(f"releases/{PRODUCT}.json", "w") as f:


### PR DESCRIPTION
Fix script to not fail if it does not contain `1.0_alpha`.

Had this error in another PR :

```
 Traceback (most recent call last):
java
    File "/home/runner/work/release-data/release-data/src/java.py", line 55, in <module>
      main()
    File "/home/runner/work/release-data/release-data/src/java.py", line 44, in main
      releases.pop('1.0_alpha') # that's the only version we do not want, regex not needed
  KeyError: '1.0_alpha'
  Error: Process completed with exit code 1.
```