### PR TITLE
[AIX] Add IBM AIX version scraper

### DIFF
--- a/src/ibm-aix.py
+++ b/src/ibm-aix.py
@@ -1,7 +1,5 @@
-import json
-import urllib.request
-
 from bs4 import BeautifulSoup
+from common import endoflife
 from datetime import datetime
 
 
@@ -9,58 +7,33 @@ PRODUCT = "ibm-aix"
 URL = "https://www.ibm.com/support/pages/aix-support-lifecycle-information"
 
 
-def fetch_releases(url):
-    headers = {"user-agent": "mozilla"}    
-    req = urllib.request.Request(url, headers=headers)
-    with urllib.request.urlopen(req, timeout=5) as response:
-        return BeautifulSoup(response, features="html5lib")
-
-
+# Convert date from e.g. "November 2022" format to "2022-11-01"
 def convert_date(date_str):
     return datetime.strptime(date_str, "%B %Y").strftime("%Y-%m-%d")
 
 
-def strip_version(version_str):
-    return version_str.strip("AIX ")
+def fetch_releases():
+    response = endoflife.fetch_url(URL)
+    soup = BeautifulSoup(response, features="html5lib")
+
+    releases = {}
+    # for all release tables
+    for release_table in soup.find("div", class_="ibm-container-body").find_all("table", class_="ibm-data-table ibm-grid"):
+        # for all rows except the header one
+        for row in release_table.find_all("tr")[1:]:
+            cells = row.find_all("td")
+            version = cells[0].text.strip("AIX ").replace(' TL', '.')
+            date = convert_date(cells[1].text)
+            print(f"{version} : {date}")
+            releases[version] = date
+
+    return releases
 
 
-"""
-Takes soup, and returns a dictionary of versions and their release dates
-"""
-def parse_soup_for_versions(soup):
-    """ Parse the soup """
-    versions = {}
-    # Get the main page content div
-    main_content = soup.find("div", class_="ibm-container-body")
-    # Parse data tables
-    for release_table in main_content.find_all("table", class_="ibm-data-table ibm-grid"):
-        # Extract rows from the table
-        rows = release_table.find_all("tr")
-        # Skip the header row
-        # Each row consists of five cells - first one is the version, the second one is the release date 
-        for tr in rows[1:]:
-            cells = tr.find_all("td")
-            # Strip the version string from unneeded "AIX " prefix
-            version = strip_version(cells[0].text)
-            # Convert date from e.g. "November 2022" format to "2022-11-01"
-            release_date = convert_date(cells[1].text)
-            versions[version] = release_date
-            print("%s: %s" % (version, release_date))
-    return versions
-
-
-def main():
-    print(f"::group::{PRODUCT}")
-    content = fetch_releases(URL)
-    releases = parse_soup_for_versions(content)
-    print("::endgroup::")
-
-    with open(f"releases/{PRODUCT}.json", "w") as f:
-        f.write(json.dumps(dict(
-            # sort by version then date (asc)
-            sorted(releases.items(), key=lambda x: (x[0], x[1]))
-        ), indent=2))
-
-
-if __name__ == "__main__":
-    main()
+print(f"::group::{PRODUCT}")
+releases = fetch_releases()
+endoflife.write_releases(PRODUCT, dict(
+    # sort by date then version (desc)
+    sorted(releases.items(), key=lambda x: (x[1], x[0]), reverse=True)
+))
+print("::endgroup::")

--- a/src/ibm-aix.py
+++ b/src/ibm-aix.py
@@ -1,0 +1,66 @@
+import json
+import urllib.request
+
+from bs4 import BeautifulSoup
+from datetime import datetime
+
+
+PRODUCT = "ibm-aix"
+URL = "https://www.ibm.com/support/pages/aix-support-lifecycle-information"
+
+
+def fetch_releases(url):
+    headers = {"user-agent": "mozilla"}    
+    req = urllib.request.Request(url, headers=headers)
+    with urllib.request.urlopen(req, timeout=5) as response:
+        return BeautifulSoup(response, features="html5lib")
+
+
+def convert_date(date_str):
+    return datetime.strptime(date_str, "%B %Y").strftime("%Y-%m-%d")
+
+
+def strip_version(version_str):
+    return version_str.strip("AIX ")
+
+
+"""
+Takes soup, and returns a dictionary of versions and their release dates
+"""
+def parse_soup_for_versions(soup):
+    """ Parse the soup """
+    versions = {}
+    # Get the main page content div
+    main_content = soup.find("div", class_="ibm-container-body")
+    # Parse data tables
+    for release_table in main_content.find_all("table", class_="ibm-data-table ibm-grid"):
+        # Extract rows from the table
+        rows = release_table.find_all("tr")
+        # Skip the header row
+        # Each row consists of five cells - first one is the version, the second one is the release date 
+        for tr in rows[1:]:
+            cells = tr.find_all("td")
+            # Strip the version string from unneeded "AIX " prefix
+            version = strip_version(cells[0].text)
+            # Convert date from e.g. "November 2022" format to "2022-11-01"
+            release_date = convert_date(cells[1].text)
+            versions[version] = release_date
+            print("%s: %s" % (version, release_date))
+    return versions
+
+
+def main():
+    print(f"::group::{PRODUCT}")
+    content = fetch_releases(URL)
+    releases = parse_soup_for_versions(content)
+    print("::endgroup::")
+
+    with open(f"releases/{PRODUCT}.json", "w") as f:
+        f.write(json.dumps(dict(
+            # sort by version then date (asc)
+            sorted(releases.items(), key=lambda x: (x[0], x[1]))
+        ), indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Added an automated release date scraper for IBM AIX operating system.
The data is taken from https://www.ibm.com/support/pages/aix-support-lifecycle-information, the official lifecycle page for this product.
The markdown page for IBM AIX will be created separately.