### PR TITLE
[apache] add automation script

### DIFF
--- a/src/apache-http-server.py
+++ b/src/apache-http-server.py
@@ -12,7 +12,7 @@ history. Not every version was released, the lines are filtered with
 consistent in the past with the wording, it seems better now).
 """
 
-PRODUCT = "apache"
+PRODUCT = "apache-http-server"
 REPO_URL = "https://github.com/apache/httpd.git"
 
 

--- a/src/apache.py
+++ b/src/apache.py
@@ -1,0 +1,69 @@
+import re
+from datetime import datetime
+from pathlib import Path
+from common import endoflife
+from common.git import Git
+
+"""
+Fetch apache versions from the git repository
+"""
+
+PRODUCT = "apache"
+REPO_URL = "https://github.com/apache/httpd.git"
+
+
+def get_versions_from_file(release_notes_file: Path) -> dict:
+    if not release_notes_file.exists():
+        return {}
+
+    with open(release_notes_file, "rb") as f:
+        plain = f.read().decode("utf-8", errors="ignore")
+
+    return {
+        version: date
+        for (version, date) in re.findall(
+            r"\s+(?P<version>\d+\.\d+\.\d+)\s*:.*(?:Released|Announced)\s(?:on\s)?(?P<date>\w+\s\d\d?,\s\d{4})",
+            plain,
+        )
+    }
+
+git = Git(REPO_URL)
+git.setup()
+versions = {}
+
+for branch in git.list_branches("refs/heads/?.?.x"):
+    status_file = "STATUS"
+    git.checkout(branch, file_list=[status_file])
+    versions = {**versions, **get_versions_from_file(git.repo_dir / status_file)}
+
+# convert the date format
+converted = {}
+for version, date in versions.items():
+    try:
+        d = datetime.strptime(date, "%B %d, %Y")
+        converted[version] = d.strftime("%Y-%m-%d")
+        continue
+    except ValueError:
+        pass
+
+    try:
+        d = datetime.strptime(date, "%b %d, %Y")
+        converted[version] = d.strftime("%Y-%m-%d")
+        continue
+    except ValueError:
+        pass
+
+versions = converted
+
+print(f"::group::{PRODUCT}")
+for version, date in versions.items():
+    print(f"{version}: {date}")
+print("::endgroup::")
+
+endoflife.write_releases(
+    PRODUCT,
+    dict(
+        # sort by date then version (desc)
+        sorted(versions.items(), key=lambda x: (x[1], x[0]), reverse=True)
+    ),
+)

--- a/src/apache.py
+++ b/src/apache.py
@@ -4,12 +4,26 @@ from pathlib import Path
 from common import endoflife
 from common.git import Git
 
-"""
-Fetch apache versions from the git repository
+"""Fetch apache versions from its git repository.
+
+Every branch formatted like 2.4.x has a STATUS file which contains a version
+history. Not every version was released, the lines are filtered with
+(?:Released|Announced) to get the released versions only (they were not
+consistent in the past with the wording, it seems better now).
 """
 
 PRODUCT = "apache"
 REPO_URL = "https://github.com/apache/httpd.git"
+
+
+def parse(date: str) -> str:
+    for format in ["%B %d, %Y", "%b %d, %Y"]:
+        try:
+            return datetime.strptime(date, format).strftime("%Y-%m-%d")
+        except ValueError:
+            pass
+
+    raise ValueError(f"Unknown date format for '{date}'")
 
 
 def get_versions_from_file(release_notes_file: Path) -> dict:
@@ -27,37 +41,19 @@ def get_versions_from_file(release_notes_file: Path) -> dict:
         )
     }
 
+
 git = Git(REPO_URL)
 git.setup()
 versions = {}
 
+print(f"::group::{PRODUCT}")
 for branch in git.list_branches("refs/heads/?.?.x"):
     status_file = "STATUS"
     git.checkout(branch, file_list=[status_file])
-    versions = {**versions, **get_versions_from_file(git.repo_dir / status_file)}
-
-# convert the date format
-converted = {}
-for version, date in versions.items():
-    try:
-        d = datetime.strptime(date, "%B %d, %Y")
-        converted[version] = d.strftime("%Y-%m-%d")
-        continue
-    except ValueError:
-        pass
-
-    try:
-        d = datetime.strptime(date, "%b %d, %Y")
-        converted[version] = d.strftime("%Y-%m-%d")
-        continue
-    except ValueError:
-        pass
-
-versions = converted
-
-print(f"::group::{PRODUCT}")
-for version, date in versions.items():
-    print(f"{version}: {date}")
+    for version, date_str in get_versions_from_file(git.repo_dir / status_file).items():
+        date = parse(date_str)
+        versions[version] = date
+        print(f"{version}: {date}")
 print("::endgroup::")
 
 endoflife.write_releases(


### PR DESCRIPTION
This script fetches informations from the https://github.com/apache/httpd repo.
Every branch formated like 2.4.x has a `STATUS` file which contains a version history.
Not every version was released, so I filter the lines with `(?:Released|Announced)` to get the released versions only (they were not rly consistent in the past with the wording, it seems better now).
They use the format `Month Day, Year` and I try to parse the date and convert it to the required format. Dates which fail this process are filtered out.