### PR TITLE
[coldfusion] Adds coldfusion release automation

### DIFF
--- a/src/coldfusion.py
+++ b/src/coldfusion.py
@@ -1,0 +1,60 @@
+import re
+from bs4 import BeautifulSoup
+from datetime import datetime
+from common import endoflife
+
+URLS = [
+    "https://helpx.adobe.com/coldfusion/kb/coldfusion-10-updates.html",
+    "https://helpx.adobe.com/coldfusion/kb/coldfusion-11-updates.html",
+    "https://helpx.adobe.com/coldfusion/kb/coldfusion-2016-updates.html",
+    "https://helpx.adobe.com/coldfusion/kb/coldfusion-2018-updates.html",
+    "https://helpx.adobe.com/coldfusion/kb/coldfusion-2021-updates.html",
+    "https://helpx.adobe.com/coldfusion/kb/coldfusion-2023-updates.html"
+]
+
+PRODUCT = "coldfusion"
+regex = r"[r|R]elease [d|D]ate[,|:]? (.*?)\).*?Build Number: (.*?)$"
+
+"""
+Make a HEAD request to the URL
+and parse the Last-Modified header
+to return a YYYY-MM-DD string
+"""
+def parse_release_date(text):
+    text = text.replace(",", "")
+    date_formats = ['%d %b %Y', '%d %B %Y', '%b %d %Y', '%B %d %Y']
+
+    for date_format in date_formats:
+        try:
+            return datetime.strptime(text, date_format).strftime("%Y-%m-%d")
+        except ValueError:
+            pass
+
+    raise ValueError("Cannot parse date '" + text + "' with formats " + str(date_formats))
+
+def parse(url, versions):
+    response = endoflife.fetch_url(url)
+    soup = BeautifulSoup(response, features="html5lib")
+    for p in soup.findAll("div", class_="text"):
+        text = p.get_text().strip().replace('\xa0', ' ')
+        matches = re.findall(regex, text, re.DOTALL | re.MULTILINE)
+        for m in matches:
+            date = parse_release_date(m[0].strip())
+            version = m[1].strip().replace(",",".")
+            versions[version] = date
+            print(f"{version}: {date}")
+
+def fetch_releases():
+    releases = {}
+    for url in URLS:
+        parse(url, releases)
+
+    return releases
+
+print(f"::group::{PRODUCT}")
+releases = fetch_releases()
+endoflife.write_releases(PRODUCT, dict(
+    # sort by version (desc)
+    sorted(releases.items(), key=lambda x: (x[0]), reverse=True)
+))
+print("::endgroup::")

--- a/src/common/dates.py
+++ b/src/common/dates.py
@@ -3,8 +3,6 @@ import calendar
 
 
 def parse_date(text, formats=frozenset([
-    "%B %d, %Y",  # January 1, 2020
-    "%b %d, %Y",  # Jan 1, 2020
     "%B %d %Y",   # January 1 2020
     "%b %d %Y",   # Jan 1 2020
     "%d %B %Y",   # 1 January 2020
@@ -33,13 +31,14 @@ def parse_datetime(text, formats=frozenset([
     "%Y-%m-%d %H:%M:%S",         # 2023-05-01 08:32:34
     "%Y-%m-%dT%H:%M:%S",         # 2023-05-01T08:32:34
     "%Y-%m-%d %H:%M:%S %z",      # 2023-05-01 08:32:34 +0900
-    "%a, %d %b %Y %H:%M:%S %Z",  # Wed, 01 Jan 2020 00:00:00 GMT
+    "%a %d %b %Y %H:%M:%S %Z",  # Wed, 01 Jan 2020 00:00:00 GMT
     "%Y-%m-%dT%H:%M:%S%z",       # 2023-05-01T08:32:34+0900
 ]), to_utc=True) -> datetime:
     """Parse a given text representing a datetime using a list of formats,
     optionally converting it to UTC.
     """
     text = text.strip()
+    text = text.replace(", ", " ")  # so that we don't have to deal with commas in formats
     for fmt in formats:
         try:
             date = datetime.strptime(text, fmt)


### PR DESCRIPTION
- Fixes #81

~~The website does not have release dates~~, so this instead fetches the hotfix by making a HEAD request instead to get the last modified date on the hotfix file.  The dates seem reasonable:

```json
{
  "10.0.19.298511": "2016-04-20",
  "10.0.20.299202": "2016-06-08",
  "10.0.21.300068": "2016-08-25",
  "10.0.22.301868": "2016-12-20",
  "10.0.23.302580": "2017-04-22",
  "11.0.01.291346": "2014-09-22",
  "11.0.02.291725": "2014-12-02",
  "11.0.03.292480": "2014-12-09",
  "11.0.04.293328": "2015-02-19",
  "2016.0.02.299200": "2016-06-08",
  "2016.0.03.300466": "2016-10-07",
  "2016.0.04.302561": "2017-04-19",
  "2016.0.05.303689": "2017-08-31",
  "2016.0.06.308055": "2018-04-09",
  "2016.0.07.311392": "2018-09-11",
  "2016.0.09.314003": "2019-02-21",
  "2016.0.10.314028": "2019-02-27",
  "2016.0.11.314546": "2019-06-07",
  "2016.0.12.315717": "2019-09-24",
  "2016.0.13.316217": "2019-11-12",
  "2016.0.14.318307": "2020-03-17",
  "2016.0.15.318650": "2020-04-14",
  "2016.0.16.320445": "2020-07-13",
  "2016.0.17.325979": "2021-03-22",
  "2018.0.01.311402": "2018-09-11",
  "2018.0.02.313961": "2019-02-04",
  "2018.0.03.314033": "2019-03-01",
  "2018.0.04.314546": "2019-06-07",
  "2018.0.05.315699": "2019-09-19",
  "2018.0.06.316308": "2019-11-13",
  "2018.0.07.316715": "2019-12-05",
  "2018.0.08.318307": "2020-03-17",
  "2018.0.09.318650": "2020-04-14",
  "2018.0.10.320417": "2020-07-13",
  "2018.0.11.326016": "2021-03-22",
  "2018.0.12.328566": "2021-09-13",
  "2018.0.13.329786": "2021-12-16",
  "2018.0.14.330003.": "2022-05-10",
  "2018.0.15.330106.": "2023-02-16",
  "2018.0.16.330130.": "2023-03-13",
  "2018.0.17.330143": "2023-07-11",
  "2018.0.18.330145": "2023-07-14",
  "2018.0.19.330149": "2023-07-19",
  "2021.0.1.325996": "2021-05-25",
  "2021.0.10.330161": "2023-08-14",
  "2021.0.11.330247": "2023-10-05",
  "2021.0.2.328618": "2021-09-20",
  "2021.0.3.329779": "2021-12-16",
  "2021.0.4.330004": "2022-05-10",
  "2021.0.5.330109": "2023-02-16",
  "2021.0.6.330132": "2023-03-13",
  "2021.0.7.330142": "2023-07-11",
  "2021.0.8.330144": "2023-07-14",
  "2021.0.9.330148": "2023-07-19",
  "2023.0.1.330480": "2023-07-11",
  "2023.0.2.330482": "2023-07-14",
  "2023.0.3.330486": "2023-07-19",
  "2023.0.4.330500": "2023-08-17",
  "2023.0.5.330608": "2023-10-06"
}
```