### PR TITLE
Only deploy for upstream

### DIFF
--- a/.github/workflows/trigger-deploy.yml
+++ b/.github/workflows/trigger-deploy.yml
@@ -12,6 +12,7 @@ on:
 jobs:
   deploy:
     name: Deploy Website
+    if: github.repository_owner == 'endoflife-date'
     runs-on: ubuntu-latest
     environment: production
     steps:


### PR DESCRIPTION
No point running for forks, it will (expectedly) fail due to missing credentials:

https://github.com/hugovk/release-data/actions/runs/6995103681