### PR TITLE
Fix some lint warnings

### DIFF
--- a/src/common/git.py
+++ b/src/common/git.py
@@ -18,7 +18,7 @@ class Git:
             child = run(f"git {cmd}", capture_output=True, timeout=300, check=True, shell=True, cwd=self.repo_dir)
             return child.stdout.decode("utf-8").strip().split("\n")
         except ChildProcessError as ex:
-            raise RuntimeError(f"Failed to run '{git_command}': {ex}")
+            raise RuntimeError(f"Failed to run '{cmd}': {ex}")
 
     def setup(self, bare: bool = False):
         """Creates the repository path and runs:

--- a/src/common/git.py
+++ b/src/common/git.py
@@ -1,6 +1,6 @@
 from hashlib import sha1
 from pathlib import Path
-from subprocess import run, PIPE
+from subprocess import run
 
 
 class Git:

--- a/src/eks.py
+++ b/src/eks.py
@@ -1,8 +1,7 @@
-import datetime
+import datetime as dt
 import re
 from bs4 import BeautifulSoup
 from common import endoflife
-from datetime import datetime
 
 # Now that AWS no longer publishes docs on GitHub,
 # we use the Web Archive to still get the older versions
@@ -32,7 +31,7 @@ def parse_platforms_pages():
                 data = tr.findAll("td")
                 date = data[-1].text.strip()
                 if len(date) > 0:
-                    d = datetime.strptime(date, "%B %d, %Y").strftime("%Y-%m-%d")
+                    d = dt.datetime.strptime(date, "%B %d, %Y").strftime("%Y-%m-%d")
                     k8s_version = ".".join(data[0].text.strip().split(".")[:-1])
                     eks_version = data[1].text.strip().replace(".", "-")
                     version = f"{k8s_version}-{eks_version}"

--- a/src/firefox.py
+++ b/src/firefox.py
@@ -3,11 +3,6 @@ import urllib.parse
 from bs4 import BeautifulSoup
 from common import endoflife
 from datetime import datetime
-from urllib3.util import Retry
-from requests.adapters import HTTPAdapter
-from requests_futures.sessions import FuturesSession
-from requests.exceptions import ChunkedEncodingError
-from concurrent.futures import as_completed
 
 """Fetch Firefox versions with their dates from https://www.mozilla.org/"""
 

--- a/src/graalvm.py
+++ b/src/graalvm.py
@@ -1,4 +1,3 @@
-import re
 from bs4 import BeautifulSoup
 from common import endoflife
 from datetime import datetime

--- a/src/ros.py
+++ b/src/ros.py
@@ -25,7 +25,7 @@ for tr in soup.findAll("tr"):
                     td_list[1].get_text().strip(), "%B %d, %Y"
                 )
             # The date is a suffix (May 23rd, 2020)
-            except ValueError as e:
+            except ValueError:
                 x = td_list[1].get_text().split(",")
                 date = datetime.datetime.strptime(x[0][:-2] + x[1], "%B %d %Y")
             abs_date = date.strftime("%Y-%m-%d")


### PR DESCRIPTION
I followed https://adamj.eu/tech/2019/09/12/how-i-import-pythons-datetime-module/ to fix the `datetime` warning.

Is there any interest in adding a linter and/or formatter to the CI?