### PR TITLE
Allow testing feature branches but don't double test interal PRs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,7 +2,6 @@ name: Lint
 
 on:
   push:
-    branches: ['main']
   pull_request:
   workflow_dispatch: # Allows running the workflow manually from the Actions tab
 
@@ -15,6 +14,10 @@ env:
 jobs:
   lint:
     runs-on: ubuntu-latest
+
+    # We want to run on external PRs, but not on our own internal PRs as they'll be run
+    # by the push to the branch.
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Re: https://github.com/endoflife-date/release-data/commit/9dfd8f4f6ee3c5f4a8b5a5cb8710e8ec3d6e5721#r133536138

This allows forks to test their feature branches before even opening a PR here. _Fail fast._

But if you create a feature branch PR from this repo, it will only trigger once.