### PR TITLE
plugin: indexpage plugin to fetch a product and versions from an ftp …

### DIFF
--- a/src/indexpage.py
+++ b/src/indexpage.py
@@ -1,0 +1,59 @@
+from bs4 import BeautifulSoup
+from common import dates
+from common import endoflife
+import regex as re
+import sys
+
+
+"""Fetch versions with their dates from apache webserver hosted indexpage .
+
+"""
+
+METHOD = 'indexpage'
+DEFAULT_VERSION_REGEX = "(\d+\.\d+\.\d+)"
+
+def fetch_releases(product_name, url, regex):
+    result = {}
+    version_pattern = re.compile(regex)
+
+    soup = make_bs_request(url)
+    for row in soup.find_all('tr'):
+        cells = row.find_all('td')
+        if len(cells) > 2:
+            link = cells[1].find('a')
+            if link and product_name in link.text:
+                version_match = version_pattern.search(link.text)
+                date_text = cells[2].text.strip()
+
+                if version_match and date_text:
+                    version = version_match.group(1)  # Extract the version number
+                    date = date_text.split(' ')[0]  # Extract the date
+                    result[version] = date
+
+    return result
+
+def make_bs_request(url):
+    response = endoflife.fetch_url(url)
+    return BeautifulSoup(response, features="html5lib")
+
+def update_product(product_name, configs):
+    versions = {}
+
+    for config in configs:
+        regex = config.get("regex", DEFAULT_VERSION_REGEX)
+        print(f"Fetching {METHOD} releases for {product_name} with regex {regex}")
+        regex_product = r'{}{}'.format(product_name, regex)
+        versions = versions | fetch_releases(product_name, config[METHOD], regex_product)
+
+    endoflife.write_releases(product_name, versions)
+
+
+
+p_filter = sys.argv[1] if len(sys.argv) > 1 else None
+print(endoflife.list_products(METHOD, p_filter))
+for product, configs in endoflife.list_products(METHOD, p_filter).items():
+    print(f"::group::{product}")
+    update_product(product, configs)
+    print("::endgroup::")
+
+


### PR DESCRIPTION
plugin: indexpage plugin to fetch a product and versions from an ftp or an apache hosted website

we need to track end of life versions for some of the open source projects hosted on a http server or an ftp site like 
- automake 
- libSM
- binutils 

This plugin provides an easy way to integrate with these sites to fetch the versions 

```
libSM.md
auto:
-   indexpage: https://www.x.org/releases/individual/lib/
    regex: -(\d+\.\d+\.\d+).tar.gz

```


the resulting versions are 

```
➜  release-data git:(main) ✗ cat releases/libSM.json 
{
  "1.2.4": "2022-12-20",
  "1.2.3": "2018-10-10",
  "1.2.2": "2013-09-08",
  "1.2.1": "2012-03-03",
  "1.2.0": "2010-10-28",
  "1.1.1": "2009-08-07",
  "1.1.0": "2008-07-02",
  "1.0.3": "2007-05-13",
  "1.0.2": "2006-10-13",
  "1.0.1": "2006-04-27",
  "1.0.0": "2006-01-18"
}%  
```
