### PR TITLE
[git] Refactor script

### DIFF
--- a/src/common/endoflife.py
+++ b/src/common/endoflife.py
@@ -2,7 +2,7 @@ import frontmatter
 import json
 import logging
 import os
-import re
+import regex as re  # Python re module does not support identically named groups (as used in the mariadb product)
 from datetime import datetime
 from glob import glob
 from liquid import Template

--- a/src/git.py
+++ b/src/git.py
@@ -1,53 +1,27 @@
-import regex as re
 import sys
+from common import dates
 from common import endoflife
 from common.git import Git
-from liquid import Template
 
-"""Fetch versions with their dates from tags in a git repository.
+"""Fetches versions from tags in a git repository. This replace the old update.rb script."""
 
-This replace the old update.rb script.
-
-Note that this script is using the regex module because the Python re module does not support
-identically named groups (as used in the mariadb product).
-"""
-
-# Default tag template and regex should include tiny version to properly handle blender,
-# craft-cms, exim, gerrit, jquery, kdeplasma, kirby, logstash, nexus, silverstripe
-# and tarantool versions.
 METHOD = 'git'
 
-
-def fetch_releases(url, regex, template):
-    releases = {}
-
-    git = Git(url)
-    git.setup(bare=True)
-
-    tags = git.list_tags()
-    for tag, date in tags:
-        match = re.match(regex, tag)
-        if match:
-            version = Template(template).render(match.groupdict())
-            releases[version] = date
-            print(f"{version}: {date}")
-
-    return releases
-
-def update_product(product_name, configs):
-    versions = {}
-
-    for config in configs:
-        t = config.get("template", endoflife.DEFAULT_VERSION_TEMPLATE)
-        regex = config.get("regex", endoflife.DEFAULT_VERSION_REGEX)
-        regex = regex.replace("(?<", "(?P<")  # convert ruby regex to python regex
-        versions = versions | fetch_releases(config[METHOD], regex, t)
-
-    endoflife.write_releases(product_name, versions)
-
-
 p_filter = sys.argv[1] if len(sys.argv) > 1 else None
-for product, configs in endoflife.list_products(METHOD, p_filter).items():
-    print(f"::group::{product}")
-    update_product(product, configs)
+for product_name, configs in endoflife.list_products(METHOD, p_filter).items():
+    print(f"::group::{product_name}")
+    product = endoflife.Product(product_name, load_product_data=True)
+    for config in product.get_auto_configs(METHOD):
+        git = Git(config.url)
+        git.setup(bare=True)
+
+        tags = git.list_tags()
+        for tag, date_str in tags:
+            version_match = config.first_match(tag)
+            if version_match:
+                version = config.render(version_match)
+                date = dates.parse_date(date_str)
+                product.declare_version(version, date)
+
+    product.write()
     print("::endgroup::")


### PR DESCRIPTION
Make the script more readable, mostly by:

- using the Product and AutoConfig classes,
- removing the use of functions when unnecessary,
- a little bit of renaming and documentation.

Note that this also changed the module used for regexes in endoflife.py. The regex module is now used because the Python re module does not support identically named groups (as used in the mariadb product). The regex module being backwards-compatible with the standard re module, this should not be an issue.