### PR TITLE
[ibm-aix] Stop fetching version from web.archive.org

### DIFF
--- a/src/ibm-aix.py
+++ b/src/ibm-aix.py
@@ -2,7 +2,8 @@ from bs4 import BeautifulSoup
 from common import dates, http, releasedata
 
 URLS = [
-    "https://web.archive.org/web/20210123024247/https://www.ibm.com/support/pages/aix-support-lifecycle-information",
+    # Disable, it causes too many timeouts / errors
+    # "https://web.archive.org/web/20210123024247/https://www.ibm.com/support/pages/aix-support-lifecycle-information",
     "https://www.ibm.com/support/pages/aix-support-lifecycle-information",
 ]
 


### PR DESCRIPTION
Disabled because it causes too many timeouts / errors, see https://github.com/endoflife-date/release-data/actions/runs/7630234550 or https://github.com/endoflife-date/release-data/actions/runs/7636410022.