### PR TITLE
[firefox][unity] Add support for cumulative updates and use it in a few scripts

### DIFF
--- a/src/aws-lambda.py
+++ b/src/aws-lambda.py
@@ -13,7 +13,6 @@ them though. Note that this would also be unnecessary if it was possible to disa
 release dates updates in the latest.py script."""
 
 with releasedata.ProductData("aws-lambda") as product_data:
-    old_product_data = releasedata.ProductData.from_file(product_data.name)
     product_frontmatter = endoflife.ProductFrontmatter(product_data.name)
     response = http.fetch_url("https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html")
     soup = BeautifulSoup(response.text, features="html5lib")
@@ -30,7 +29,7 @@ with releasedata.ProductData("aws-lambda") as product_data:
 
             date = product_frontmatter.get_release_date(identifier)  # use the product releaseDate if available
             if date is None:
-                date = old_product_data.get_version(identifier).date()  # else use the previously found date
+                date = product_data.get_previous_version(identifier).date()  # else use the previously found date
             if date is None:
                 date = dates.today()  # else use today's date
 

--- a/src/firefox.py
+++ b/src/firefox.py
@@ -1,45 +1,33 @@
-import re
 import urllib.parse
-from itertools import islice
 
 from bs4 import BeautifulSoup
 from common import dates, http, releasedata
 
 """Fetch Firefox versions with their dates from https://www.mozilla.org/.
 
-Versions lower than 10.0 are ignored because too difficult to parse."""
+This script is cumulative: previously found versions are kept, and eventually updated if needed. It only considers the
+first MAX_VERSIONS_COUNT versions on Firefox release page because:
+- it is too long to fetch them all (at least a minute usually),
+- this generates too many requests to the mozilla.org servers,
+- and anyway oldest versions are never updated.
 
+Note that it was assumed that:
+- the script is ran regularly enough to keep the versions up to date (once a day or week looks enough),
+- the versions are listed in descending order on the page,
+- new versions are always added inside in the last MAX_VERSIONS_COUNT versions.
 
-# Will be replaced by itertools.batched in Python 3.12+.
-# See https://docs.python.org/3/library/itertools.html#itertools.batched.
-def batched(iterable: iter, n: int) -> iter:
-    if n < 1:
-        msg = 'n must be at least one'
-        raise ValueError(msg)
-    it = iter(iterable)
-    while batch := tuple(islice(it, n)):
-        yield batch
+The script will need to be updated if someday those conditions are not met."""
 
+MAX_VERSIONS_LIMIT = 50
 
-with releasedata.ProductData("firefox") as product_data:
+with releasedata.ProductData("firefox", cumulative_update=True) as product_data:
     releases_page = http.fetch_url("https://www.mozilla.org/en-US/firefox/releases/")
     releases_soup = BeautifulSoup(releases_page.text, features="html5lib")
     releases_list = releases_soup.find_all("ol", class_="c-release-list")
+
     release_notes_urls = [urllib.parse.urljoin(releases_page.url, p.get("href")) for p in releases_list[0].find_all("a")]
-
-    for batch_release_notes_urls in batched(release_notes_urls, 20):
-        for release_notes in http.fetch_urls(batch_release_notes_urls):
-            version = release_notes.url.split("/")[-3]
-
-            release_notes_soup = BeautifulSoup(release_notes.text, features="html5lib")
-            date_elt = release_notes_soup.find(class_="c-release-date")
-            if date_elt:
-                date = dates.parse_date(date_elt.get_text())
-                product_data.declare_version(version, date)
-                continue
-
-            date_elt = release_notes_soup.find("small", string=re.compile("^.?First offered"))
-            if date_elt:
-                date = dates.parse_date(' '.join(date_elt.get_text().split(" ")[-3:]))  # get last 3 words
-                product_data.declare_version(version, date)
-            # versions < 10.0 are ignored
+    for release_notes in http.fetch_urls(release_notes_urls[:MAX_VERSIONS_LIMIT]):
+        version = release_notes.url.split("/")[-3]
+        release_notes_soup = BeautifulSoup(release_notes.text, features="html5lib")
+        date_str = release_notes_soup.find(class_="c-release-date").get_text()  # note: only works for versions > 25
+        product_data.declare_version(version, dates.parse_date(date_str))

--- a/src/unity.py
+++ b/src/unity.py
@@ -1,25 +1,27 @@
 from bs4 import BeautifulSoup
 from common import dates, http, releasedata
 
-# Fetches the Unity LTS releases from the Unity website. Non-LTS releases are not listed there,
-# so this automation is only partial.
-#
-# This script iterates over all pages of the Unity LTS releases page, which is paginated.
-# It keeps fetching the next page until there is no next page link.
+"""Fetches the Unity LTS releases from the Unity website. Non-LTS releases are not listed there, so this automation
+is only partial.
 
-BASE_URL = "https://unity.com/releases/editor/qa/lts-releases"
+This script is cumulative, only the first page is fetched (e.g. the first ten versions). This is because:
+- it is too long to fetch all (at least 30s, usually more than a minute),
+- this generates too many requests to the unity.com servers,
+- fetching multiple pages in parallel is raising a lot of errors and makes the overall process slower (this was tested
+  during https://github.com/endoflife-date/release-data/pull/194),
+- and anyway oldest versions are never updated.
 
-next_page_url = BASE_URL
-with releasedata.ProductData("unity") as product_data:
-    # Do not try to fetch multiple pages in parallel: it is raising a lot of errors and make the overall process slower.
-    while next_page_url:
-        response = http.fetch_url(next_page_url)
-        soup = BeautifulSoup(response.text, features="html5lib")
+Note that it was assumed that:
+- the script is ran regularly enough to keep the versions up to date (once a day or week looks enough),
+- there is never more than 10 new LTS versions at a time.
 
-        for release in soup.find_all('div', class_='component-releases-item__show__inner-header'):
-            version = release.find('h4').find('span').text
-            date = dates.parse_datetime(release.find('time').attrs['datetime'])
-            product_data.declare_version(version, date)
+The script will need to be updated if someday those conditions are not met."""
 
-        next_link = soup.find('a', {"rel": "next"})
-        next_page_url = BASE_URL + next_link.attrs['href'] if next_link else None
+with releasedata.ProductData("unity", cumulative_update=True) as product_data:
+    response = http.fetch_url("https://unity.com/releases/editor/qa/lts-releases")
+    soup = BeautifulSoup(response.text, features="html5lib")
+
+    for release in soup.find_all('div', class_='component-releases-item__show__inner-header'):
+        version = release.find('h4').find('span').text
+        date = dates.parse_datetime(release.find('time').attrs['datetime'])
+        product_data.declare_version(version, date)


### PR DESCRIPTION
Generic support for cumulative updates has been added to speed up execution time of some scripts that were very long (in comparison with the vast majority of products), usually because they were involving a lot of HTTP requests.

This feature was developed particularily for the firefox.py and unity.py scripts, which was often very long to execute (a minute or moreaccording to GHA summaries). Those scripts has been updated to make use of this new feature.