### PR TITLE
Stop wrapping line when updating product data

### DIFF
--- a/latest.py
+++ b/latest.py
@@ -178,6 +178,7 @@ class Product:
             product_file.write("---\n")
 
             yaml_frontmatter = YAML()
+            yaml_frontmatter.width = 4096  # prevent line-wrap
             yaml_frontmatter.indent(sequence=4)
             yaml_frontmatter.dump(self.data, product_file)
 


### PR DESCRIPTION
Such as https://github.com/endoflife-date/endoflife.date/commit/688beefd7ab7e047a2b9ce04b308dfffc916aa00.