### PR TITLE
[github_releases] Use tag name instead of release name

### DIFF
--- a/src/github_releases.py
+++ b/src/github_releases.py
@@ -18,7 +18,7 @@ for config in endoflife.list_configs(p_filter, METHOD, m_filter):
             if release.is_prerelease:
                 continue
 
-            version_str = release.name
+            version_str = release.tag_name
             version_match = config.first_match(version_str)
             if version_match:
                 version = config.render(version_match)


### PR DESCRIPTION
It is usually simpler to parse, align with the `git`method, and gives better results by default.