### PR TITLE
Fix openshift pattern

### DIFF
--- a/src/red-hat-openshift.py
+++ b/src/red-hat-openshift.py
@@ -6,7 +6,7 @@ from common.git import Git
 """Fetches Red Hat OpenShift versions from the documentation's git repository"""
 
 VERSION_AND_DATE_PATTERN = re.compile(
-    r"{product-title}\s(?P<version>\d+\.\d+\.\d+).*\n+Issued:\s(?P<date>\d{4}-\d\d-\d\d)$",
+    r"{product-title}\s(?P<version>{product-version}\.\d+|\d+\.\d+\.\d+).*\n+Issued:\s(?P<date>\d\d?\s[a-zA-Z]+\s\d{4}|\d{4}-\d\d-\d\d)$",
     re.MULTILINE,
 )
 
@@ -16,8 +16,9 @@ with releasedata.ProductData("red-hat-openshift") as product_data:
 
     # only fetch v4+ branches, because the format was different in openshift v3
     for branch in git.list_branches("refs/heads/enterprise-[4-9]*"):
-        version = branch.split("-")[1].replace(".", "-")
-        release_notes_filename = f"release_notes/ocp-{version}-release-notes.adoc"
+        branch_version = branch.split("-")[1]
+        file_version = branch_version.replace(".", "-")
+        release_notes_filename = f"release_notes/ocp-{file_version}-release-notes.adoc"
         git.checkout(branch, file_list=[release_notes_filename])
 
         release_notes_file = git.repo_dir / release_notes_filename
@@ -27,4 +28,7 @@ with releasedata.ProductData("red-hat-openshift") as product_data:
         with release_notes_file.open("rb") as f:
             content = f.read().decode("utf-8")
             for version, date_str in VERSION_AND_DATE_PATTERN.findall(content):
-                product_data.declare_version(version, dates.parse_date(date_str))
+                product_data.declare_version(
+                    version.replace("{product-version}", branch_version),
+                    dates.parse_date(date_str),
+                )

--- a/src/red-hat-openshift.py
+++ b/src/red-hat-openshift.py
@@ -5,7 +5,10 @@ from common.git import Git
 
 """Fetches Red Hat OpenShift versions from the documentation's git repository"""
 
-VERSION_AND_DATE_PATTERN = re.compile(r"{product-title}\s(?P<version>\d+\.\d+\.\d+).*\n+Issued:\s(?P<date>\d{4}-\d\d-\d\d)$", re.MULTILINE)
+VERSION_AND_DATE_PATTERN = re.compile(
+    r"{product-title}\s(?P<version>\d+\.\d+\.\d+).*\n+Issued:\s(?P<date>\d{4}-\d\d-\d\d)$",
+    re.MULTILINE,
+)
 
 with releasedata.ProductData("red-hat-openshift") as product_data:
     git = Git("https://github.com/openshift/openshift-docs.git")
@@ -23,5 +26,5 @@ with releasedata.ProductData("red-hat-openshift") as product_data:
 
         with release_notes_file.open("rb") as f:
             content = f.read().decode("utf-8")
-            for (version, date_str) in VERSION_AND_DATE_PATTERN.findall(content):
+            for version, date_str in VERSION_AND_DATE_PATTERN.findall(content):
                 product_data.declare_version(version, dates.parse_date(date_str))


### PR DESCRIPTION
The Red Hat people changed the [format of the dates](https://github.com/openshift/openshift-docs/commit/5b65b4de8d6e98f5e4de297300f8c25d597ffbe5) AND the format of the versions from this:

`=== RHSA-2024:5808 - {product-title} 4.12.64 bug fix and security update`

to this

`=== RHSA-2024:0041 - {product-title} {product-version}.0 image release, bug fix, and security update advisory`.

But not for all branches, but only for the latest (4.16 and up).

Fixes #378 