### PR TITLE
Add log group for loaded product data

### DIFF
--- a/update.py
+++ b/update.py
@@ -101,7 +101,10 @@ def __run_script(product: ProductFrontmatter, config: AutoConfig, summary: Scrip
 def run_scripts(summary: GitHubStepSummary, product_filter: str) -> bool:
     exec_summary = ScriptExecutionSummary()
 
-    for product in list_products(product_filter):
+    with GitHubGroup("Load Product Data"):
+        product_list = list_products(product_filter)
+
+    for product in product_list:
         if not product.has_auto_configs():
             continue
 


### PR DESCRIPTION
The update.py script logs loaded product data. As they are not contained within a log group, they clutter the GitHub Actions log without really providing any benefit. By moving them into a group, they are hidden by default.