### PR TITLE
[jira][confluence] Tweak script to wait until the page is fully rendered

### DIFF
--- a/src/confluence.py
+++ b/src/confluence.py
@@ -6,7 +6,7 @@ from common import dates, http, releasedata
 Note that requests_html is used because JavaScript is needed to render the page."""
 
 with releasedata.ProductData("confluence") as product_data:
-    content = http.fetch_javascript_url("https://www.atlassian.com/software/confluence/download-archives")
+    content = http.fetch_javascript_url("https://www.atlassian.com/software/confluence/download-archives", wait_until="networkidle")
     soup = BeautifulSoup(content, 'html.parser')
 
     for version_block in soup.select('.versions-list'):

--- a/src/jira.py
+++ b/src/jira.py
@@ -6,7 +6,7 @@ from common import dates, http, releasedata
 Note that requests_html is used because JavaScript is needed to render the page."""
 
 with releasedata.ProductData("jira") as product_data:
-    content = http.fetch_javascript_url("https://www.atlassian.com/software/jira/update")
+    content = http.fetch_javascript_url("https://www.atlassian.com/software/jira/update", wait_until="networkidle")
     soup = BeautifulSoup(content, 'html.parser')
 
     for version_block in soup.select('.versions-list'):


### PR DESCRIPTION
Scripts for Jira and Confluence regularly fails because the page is not fully rendered when it is parsed.