### PR TITLE
Revert "Bump ruamel-yaml-clib from 0.2.8 to 0.2.12"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,5 +11,5 @@ requests==2.32.3 # used in http.py to make HTTP requests simpler
 requests-futures==1.0.2 # used in http.py to be able to make async HTTP requests
 requests-cache==1.2.1 # used in http.py to be able to cache HTTP requests
 ruamel.yaml==0.18.6 # used in latest.py
-ruamel.yaml.clib==0.2.12 # used in latest.py
+ruamel.yaml.clib==0.2.8 # used in latest.py
 soupsieve==2.6 # used in conjunction with beautifulsoup4


### PR DESCRIPTION
Reverts endoflife-date/release-data#386, 0.2.12 not available during Netlify build (https://app.netlify.com/sites/endoflife-date/deploys/67577a6c7a621e0008069da6).