### PR TITLE
[common http] improve the User-Agent identification

### DIFF
--- a/src/common/http.py
+++ b/src/common/http.py
@@ -16,7 +16,7 @@ from requests_futures.sessions import FuturesSession
 from urllib3.util import Retry
 
 # See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent.
-USER_AGENT = 'Mozilla/5.0 (compatible; endoflife.date automation; +https://endoflife.date)'
+USER_AGENT = 'endoflife.date-bot/1.0 (endoflife.date automation; +https://endoflife.date/bot)'
 
 
 def fetch_urls(urls: list[str], data: any = None, headers: dict[str, str] = None,


### PR DESCRIPTION
Proposing a `+1 –1` change, simple to review.

Three issues about it.


### Issue 1: high entropy / uniqueness

Despite the very recent bump in #283 — `Firefox/115.0` is already "too old" :expressionless: it's two ESR's behind the latest 140.0.
  * This gives the token `Firefox/115.0` enough uniqueness to stick out as **0.23%** of all browsers' UA strings. https://browsersl.ist/#q=Firefox+115
  * Better yet, the `X11; Linux` token — amplifies that uniqueness even further  (50× maybe 200×, I didn't find solid data)

Together, this makes for a UA string rare enough (~one in a thousand *browsers*) to cause additional scrutiny & attention from bots on the AI WAF side of the fence.

In other words, this non-unique but rare UA-string may give out spoofing (which in this case, it genuinely is). This then causes some WAFs to raise suspicion, and start giving captcha challenges.


### Issue 2: (too quickly) moving target for spoofing

As said: browser versions move fast, and so trying the mimickry as (an up-to-date version of!) a browser — will cause a never-ending trickle of churn in this line of code.

Setting a more straightforward static UA string can stop that churn.

I'm proposing:
```
USER_AGENT = 'Mozilla/5.0 (compatible; endoflife.date automation; +https://endoflife.date)'
```

as this follows the standard format for identification of well-behaved www bots.


### Issue 3: Anubis, CloudFlare... AI WAFs

There's another reason to properly identify web bots, and to avoid mimicking as a browser... Identification. :thinking:

Perhaps easier to explain in context; consider https://github.com/endoflife-date/endoflife.date/pull/7781 as a use-case. Anubis [supports](https://github.com/TecharoHQ/anubis/blob/main/docs/docs/admin/policies.mdx) bot policy rules — so, one way to resolve the issue, would've been:

 * GHC Gitlab to enlist endoflife.date automation as legit captcha-free client.

But... **how** would they do that? Do you see the issue.
If we mimickry as a browser here — they don't have any good way to write that rule.
If we instead say `User-Agent: ... endoflife.date ...` that rule becomes trivial — I would've requested its addition by now.

----

@marcwrobel @captn3m0 please review.

Not sure how best to test this — I'd run `update-release-data.py` (on the branch), and it seemed to work alright. But this, of course, depends on network location, time of day & moods of the sky.

If there're indeed issues with Anubis / WAFs alike — this change should pave the way forward. LMKWDYT