### PR TITLE
Normalize release names

### DIFF
--- a/src/common/releasedata.py
+++ b/src/common/releasedata.py
@@ -153,6 +153,8 @@ class ProductData:
             }, indent=2))
 
     def get_release(self, release_name: str) -> ProductRelease:
+        release_name = endoflife.to_identifier(release_name)
+
         if release_name not in self.releases:
             logging.info(f"adding release {release_name} to {self}")
             self.releases[release_name] = ProductRelease.of(self.name, release_name)


### PR DESCRIPTION
Automatically normalize release names. This may be useful in a few situations to avoid having to write a custom script.