### PR TITLE
Improve string to identifier transformation

### DIFF
--- a/src/common/endoflife.py
+++ b/src/common/endoflife.py
@@ -135,6 +135,6 @@ def list_products(products_dir: Path, product_name: str = None) -> list[ProductF
 def to_identifier(s: str) -> str:
     """Convert a string to a valid endoflife.date identifier."""
     identifier = s.strip().lower()
-    identifier = identifier.replace(" ", "-")
+    identifier = re.sub(r"\s+", "-", identifier)
     identifier = re.sub(r"-+", "-", identifier)
     return re.sub(r"[^a-z0-9.\-+_]", "", identifier)


### PR DESCRIPTION
Include all spaces characters (matching \s in a regex), not just the standard space character.