### PR TITLE
Stop auto-updating release dates

### DIFF
--- a/src/common/endoflife.py
+++ b/src/common/endoflife.py
@@ -64,7 +64,7 @@ class ProductFrontmatter:
         if self.path.is_file():
             with self.path.open() as f:
                 self.data = frontmatter.load(f)
-                logging.info(f"loaded product data for {self.name} from {self.path}")
+                logging.debug(f"loaded product data for {self.name} from {self.path}")
         else:
             logging.warning(f"no product data found for {self.name} at {self.path}")
 


### PR DESCRIPTION
Often the actual release date does not exactly match with the first version date of for a given release. Moreover the release date is simple to set : this is a one-time update that is not subject to change.