### PR TITLE
Improve stale release warning feature

### DIFF
--- a/update-product-data.py
+++ b/update-product-data.py
@@ -258,9 +258,11 @@ def __raise_alert_for_unmatched_releases(name: str, output: GitHubOutput, produc
 
 
 def __raise_alert_for_stale_releases(name: str, output: GitHubOutput, product: Product) -> None:
-    threshold = product.data.get("staleReleaseThresholdYears", 1) * 365
+    global_threshold = product.data.get("staleReleaseThresholdDays", 365)
 
     for release in product.releases:
+        threshold = release.data.get("staleReleaseThresholdDays", global_threshold)
+
         logging.debug(f"checking staleness of {name}:{release.name}")
         eol = release.eol()
 


### PR DESCRIPTION
- Use days instead of years to be aligned with the warning message,
- Allow configure a threshold per release.