### PR TITLE
[rocky-linux] Fix script for future releases

### DIFF
--- a/src/rocky-linux.py
+++ b/src/rocky-linux.py
@@ -1,3 +1,5 @@
+import logging
+
 from common import dates, http
 from common.releasedata import ProductData, config_from_argv
 
@@ -8,5 +10,8 @@ with ProductData(config.product) as product_data:
         items = line.split('|')
         if len(items) >= 5 and config.first_match(items[1].strip()):
             version = items[1].strip()
-            date = dates.parse_date(items[3])
-            product_data.declare_version(version, date)
+            try:
+                date = dates.parse_date(items[3])
+                product_data.declare_version(version, date)
+            except Exception as e:
+                logging.exception(f"Could not process release {version} for {config.product}: {e}")


### PR DESCRIPTION
Future releases may be declared in the table with a year-month date, ignoring those release.