### PR TITLE
Revert "Bump requests from 2.33.1 to 2.34.2"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ playwright==1.59.0 # used by a few scripts to parse html
 pre-commit==3.5.0 # used to check code before commit
 python-frontmatter==1.3.0 # used in endoflife.py to parse products YAML frontmatters
 python-liquid==2.2.0 # used in endoflife.py to render version templates
-requests==2.34.2 # used in http.py to make HTTP requests simpler
+requests==2.33.1 # used in http.py to make HTTP requests simpler
 requests-futures==1.0.2 # used in http.py to be able to make async HTTP requests
 requests-cache==1.3.1 # used in http.py to be able to cache HTTP requests
 ruamel.yaml==0.19.1 # used in update-product-data.py


### PR DESCRIPTION
Reverts endoflife-date/release-data#575 because of https://github.com/endoflife-date/release-data/actions/runs/26911851812.