### PR TITLE
[cip-lifecycle] Add scraper for CIP kernel SLTS lifecycle dates

### DIFF
--- a/src/cip_lifecycle.py
+++ b/src/cip_lifecycle.py
@@ -1,0 +1,95 @@
+"""Fetches CIP SLTS lifecycle dates from gitlab.com/cip-project/cip-lifecycle.
+
+The ``cip-kernel.yml`` file references YAML anchors defined in ``kernel.yml``
+from the same repository, so both files are concatenated before parsing so
+that aliases resolve in a single pass.
+
+Each version's ``schedule`` is a list of phases. The product declares a
+``fields`` mapping from an endoflife.date field name to a ``<phase>.<key>``
+reference, for example ``eoes: phase2.end`` to map the end of CIP phase 2 to
+the ``eoes`` field.
+
+Version entries of the form ``4.19(-rt)`` cover both the standard and ``-rt``
+variants; the parenthesised suffix is stripped before applying the version
+regex. Pure ``-rt`` entries (for example ``4.4-rt``) are filtered out by the
+regex.
+
+If no field is applied at the end of the run, the script raises an error so
+that upstream format drift is surfaced loudly instead of silently producing a
+release with no extended-support data.
+"""
+
+import logging
+import re
+
+import yaml
+from common import http
+from common.releasedata import ProductData, config_from_argv
+
+CIP_REPO_RAW = "https://gitlab.com/cip-project/cip-lifecycle/-/raw/master"
+LIFECYCLE_FILES = ("kernel.yml", "cip-kernel.yml")
+RT_SUFFIX = re.compile(r"\(-rt\)$")
+
+config = config_from_argv()
+
+field_mapping: dict[str, str] = config.data.get("fields", {})
+if not field_mapping:
+    message = f"no 'fields' mapping in auto config for {config}"
+    raise ValueError(message)
+
+responses = [http.fetch_url(f"{CIP_REPO_RAW}/{name}") for name in LIFECYCLE_FILES]
+for response in responses:
+    response.raise_for_status()
+
+combined_text = "\n".join(response.text for response in responses)
+projects = yaml.safe_load(combined_text)
+
+project = next((p for p in projects if p.get("name") == config.url), None)
+if project is None:
+    message = f"project '{config.url}' not found in CIP lifecycle YAML"
+    raise ValueError(message)
+
+applied_field_count = 0
+with ProductData(config.product) as product_data:
+    for entry in project.get("versions", []):
+        raw_version = entry.get("version", "")
+        normalized = RT_SUFFIX.sub("", raw_version)
+        match = config.first_match(normalized)
+        if not match:
+            logging.debug(f"skipping CIP version '{raw_version}' (no regex match)")
+            continue
+
+        release_name = config.render(match)
+        phases_by_name = {p.get("phase"): p for p in entry.get("schedule", [])}
+
+        # Resolve all field values first so we only touch the release when there is
+        # at least one value to set; this avoids creating empty release entries
+        # when the source format drifts.
+        field_values: dict[str, object] = {}
+        for field_name, phase_ref in field_mapping.items():
+            phase_name, _, key = phase_ref.partition(".")
+            if not key:
+                logging.warning(
+                    f"invalid mapping '{field_name}: {phase_ref}', expected '<phase>.<key>'",
+                )
+                continue
+            phase = phases_by_name.get(phase_name)
+            if phase is None or phase.get(key) is None:
+                logging.warning(f"{release_name}: '{phase_ref}' not present in CIP schedule")
+                continue
+            field_values[field_name] = phase[key]
+
+        if not field_values:
+            continue
+
+        release = product_data.get_release(release_name)
+        for field_name, value in field_values.items():
+            release.set_field(field_name, value)
+            applied_field_count += 1
+
+if applied_field_count == 0:
+    message = (
+        f"no CIP lifecycle fields were applied for {config}; "
+        "upstream YAML structure may have changed"
+    )
+    raise ValueError(message)


### PR DESCRIPTION
Adds a new scraper, `src/cip_lifecycle.py`, that fetches CIP kernel SLTS lifecycle dates from `gitlab.com/cip-project/cip-lifecycle` and maps them onto endoflife.date fields. This is the data side of the follow-up requested in [endoflife-date/endoflife.date#10228](https://github.com/endoflife-date/endoflife.date/issues/10228), which itself follows on from [endoflife-date/endoflife.date#10227](https://github.com/endoflife-date/endoflife.date/pull/10227) and closes [endoflife-date/endoflife.date#3990](https://github.com/endoflife-date/endoflife.date/issues/3990).

## What it does

- Fetches `kernel.yml` and `cip-kernel.yml` from the CIP repo and concatenates them before parsing, so the cross-file YAML anchors that `cip-kernel.yml` references (defined in `kernel.yml`) resolve in a single pass.
- Selects the project named in the `auto` config's URL field (e.g. `CIP kernel`).
- Walks each version's `schedule`, indexed by phase name, and maps a configurable `<phase>.<key>` reference onto each endoflife.date field declared in `fields`.
- Filters version names: pure `-rt` entries are excluded by the user's version regex; combined entries of the form `4.19(-rt)` have the parenthesised suffix stripped before matching, so they flow through under the standard version name.
- Raises if zero fields end up being applied, surfacing upstream format drift instead of silently producing a release with no extended-support data.

## Companion product config (planned follow-up PR on the main repo)

```yaml
auto:
  methods:
    - github_tags: gregkh/linux
    - cip_lifecycle: CIP kernel
      regex: '^(?P<major>\d+)\.(?P<minor>\d+)$'
      fields:
        eoes: phase2.end
```

## Validation

Ran locally against the main repo's `products/linux-kernel.md` (with the planned `auto.methods` block added temporarily):

```
loaded data for linux-kernel from releases\linux-kernel.json
Returning '4.4' as it matches include pattern '^(?P<major>\d+)\.(?P<minor>\d+)$'
adding release 4.4 to linux-kernel
set 'eoes' in linux-kernel#4.4 to 2027-01-01
4.4-rt does not match any include or exclude patterns
Returning '4.19' as it matches include pattern '^(?P<major>\d+)\.(?P<minor>\d+)$'
adding release 4.19 to linux-kernel
set 'eoes' in linux-kernel#4.19 to 2029-01-01
Returning '5.10' as it matches include pattern '^(?P<major>\d+)\.(?P<minor>\d+)$'
adding release 5.10 to linux-kernel
set 'eoes' in linux-kernel#5.10 to 2031-01-01
5.10-rt does not match any include or exclude patterns
Returning '6.1' as it matches include pattern '^(?P<major>\d+)\.(?P<minor>\d+)$'
adding release 6.1 to linux-kernel
set 'eoes' in linux-kernel#6.1 to 2033-01-01
updating releases\linux-kernel.json data
```

Dates match the values currently hand-maintained in the main repo and the authoritative CIP source. `pre-commit run --files src/cip_lifecycle.py` passes (ruff + the pre-commit-hooks checks).

`releases/linux-kernel.json` is intentionally left untouched in this PR (matching the pattern of recent scraper-only PRs such as #102 and #103); CI will populate the `releases` section on the first scheduled run after the corresponding `auto.methods` block lands on the main repo.

## Closes

Tracking: endoflife-date/endoflife.date#10228
