### PR TITLE
[red-hat-openshift] Fixes eol.date for newer versions than OpenShift 4.19.19

### DIFF
--- a/src/red-hat-openshift.py
+++ b/src/red-hat-openshift.py
@@ -1,4 +1,5 @@
 import re
+from pathlib import Path
 
 from common import dates
 from common.git import Git
@@ -7,14 +8,21 @@ from common.releasedata import ProductData, config_from_argv
 """Fetches Red Hat OpenShift versions from the documentation's git repository"""
 
 VERSION_AND_DATE_PATTERN = re.compile(
-    r"{product-title}\s(?P<version>{product-version}\.\d+|\d+\.\d+\.\d+).*\n+Issued:\s(?P<date>\d\d?\s[a-zA-Z]+\s\d{4}|\d{4}-\d\d-\d\d)$",
+    r"{product-title}\s(?P<version>{product-version}\.\d+|\d+\.\d+\.\d+).*\n+"
+    r"(?:\[role=.*?\]\s*\n+)?"  # some module files have a "[role=...]" line before "Issued:"
+    r"Issued:\s(?P<date>\d\d?\s[a-zA-Z]+\s\d{4}|\d{4}-\d\d-\d\d)$",
     re.MULTILINE,
 )
 
-MODULE_INCLUDE_PATTERN = re.compile(r"^include::(?P<path>modules/zstream-[^]]+\.adoc)\[", re.MULTILINE)
+# Only match module files that can contain a version/date (either the bare
+# "zstream-<version>.adoc" or the older "zstream-<version>-about.adoc" split
+# style). This excludes companion files like "-bug-fixes.adoc", "-fixed-issues.adoc"
+# and "-updating.adoc", which never match VERSION_AND_DATE_PATTERN and would
+# otherwise be fetched for nothing.
+MODULE_INCLUDE_PATTERN = re.compile(r"^include::(?P<path>modules/zstream-[\d-]+(?:-about)?\.adoc)\[", re.MULTILINE)
 
 
-def _read_text(path) -> str:
+def _read_text(path: Path) -> str:
     with path.open("rb") as f:
         return f.read().decode("utf-8")
 
@@ -47,7 +55,11 @@ with ProductData(config.product) as product_data:
 
         content = _read_text(release_notes_file)
 
-        # Newer OpenShift release notes include z-stream entries from module files.
+        # Older releases are declared inline in the main release notes file, while
+        # newer z-stream entries are pulled in from separate module files. A single
+        # branch can contain both, so both need to be parsed.
+        _declare_versions_from_content(product_data, content, branch_version)
+
         module_files = MODULE_INCLUDE_PATTERN.findall(content)
         if module_files:
             git.checkout(branch, file_list=[release_notes_filename, *module_files])
@@ -57,8 +69,3 @@ with ProductData(config.product) as product_data:
                     continue
 
                 _declare_versions_from_content(product_data, _read_text(module_path), branch_version)
-
-            continue
-
-        # Fallback for older branches where release notes are still inline.
-        _declare_versions_from_content(product_data, content, branch_version)

--- a/src/red-hat-openshift.py
+++ b/src/red-hat-openshift.py
@@ -11,6 +11,21 @@ VERSION_AND_DATE_PATTERN = re.compile(
     re.MULTILINE,
 )
 
+MODULE_INCLUDE_PATTERN = re.compile(r"^include::(?P<path>modules/zstream-[^]]+\.adoc)\[", re.MULTILINE)
+
+
+def _read_text(path) -> str:
+    with path.open("rb") as f:
+        return f.read().decode("utf-8")
+
+
+def _declare_versions_from_content(product_data: ProductData, content: str, branch_version: str) -> None:
+    for version, date_str in VERSION_AND_DATE_PATTERN.findall(content):
+        product_data.declare_version(
+            version.replace("{product-version}", branch_version),
+            dates.parse_date(date_str),
+        )
+
 config = config_from_argv()
 with ProductData(config.product) as product_data:
     git = Git(config.url)
@@ -18,6 +33,9 @@ with ProductData(config.product) as product_data:
 
     # only fetch v4+ branches, because the format was different in openshift v3
     for branch in git.list_branches("refs/heads/enterprise-[4-9]*"):
+        if "-archive-" in branch:
+            continue
+
         branch_version = branch.split("-")[1]
         file_version = branch_version.replace(".", "-")
         release_notes_filename = f"release_notes/ocp-{file_version}-release-notes.adoc"
@@ -27,10 +45,20 @@ with ProductData(config.product) as product_data:
         if not release_notes_file.exists():
             continue
 
-        with release_notes_file.open("rb") as f:
-            content = f.read().decode("utf-8")
-            for version, date_str in VERSION_AND_DATE_PATTERN.findall(content):
-                product_data.declare_version(
-                    version.replace("{product-version}", branch_version),
-                    dates.parse_date(date_str),
-                )
+        content = _read_text(release_notes_file)
+
+        # Newer OpenShift release notes include z-stream entries from module files.
+        module_files = MODULE_INCLUDE_PATTERN.findall(content)
+        if module_files:
+            git.checkout(branch, file_list=[release_notes_filename, *module_files])
+            for module_file in module_files:
+                module_path = git.repo_dir / module_file
+                if not module_path.exists():
+                    continue
+
+                _declare_versions_from_content(product_data, _read_text(module_path), branch_version)
+
+            continue
+
+        # Fallback for older branches where release notes are still inline.
+        _declare_versions_from_content(product_data, content, branch_version)


### PR DESCRIPTION
Red Hat has changed the layout of its documentation. As a result, newer versions of OpenShift are no longer found using `eol.date`. From OpenShift version 4.19.19 onwards, the release notes are embedded via `includes`. 
This fix should close https://github.com/endoflife-date/endoflife.date/issues/9525

references:

- https://github.com/openshift/openshift-docs/blob/cb143375e1ab334cf2f7d3550d22926f84f4d9ed/release_notes/ocp-4-19-release-notes.adoc?plain=1#L2978-L3029