### PR TITLE
[git] Enhance git commands execution

### DIFF
--- a/src/common/git.py
+++ b/src/common/git.py
@@ -14,15 +14,15 @@ class Git:
         self.url: str = url
         self.repo_dir: Path = Path(f"~/.cache/git/{sha1(url.encode()).hexdigest()}").expanduser()
 
-    def _run(self, cmd: str) -> list:
+    def _run(self, args: list[str]) -> list:
         """Run git command and return command result as a list of lines.
         """
         try:
-            logging.info(f"Running 'git {cmd}' on {self.url}")
-            child = run(f"git {cmd}", capture_output=True, timeout=300, check=True, shell=True, cwd=self.repo_dir)
+            logging.info(f"Running 'git {' '.join(args)}' on {self.url}")
+            child = run(["git", *args], capture_output=True, timeout=300, check=True, cwd=self.repo_dir)
             return child.stdout.decode("utf-8").strip().split("\n")
         except ChildProcessError as ex:
-            msg = f"Failed to run '{cmd}': {ex}"
+            msg = f"Failed to run '{' '.join(args)}': {ex}"
             raise RuntimeError(msg) from ex
 
     def setup(self, bare: bool = False) -> None:
@@ -32,27 +32,32 @@ class Git:
         """
         if not Path(f"{self.repo_dir}").exists():
             self.repo_dir.mkdir(parents=True, exist_ok=True)
-            bare = "--bare" if bare else ""
-            self._run(f"init {bare}")
-            self._run(f"remote add origin {self.url}")
+            init_args = ["init", "--bare"] if bare else ["init"]
+            self._run(init_args)
+            self._run(["remote", "add", "origin", self.url])
 
     # See https://stackoverflow.com/a/65746233/374236
     def list_tags(self) -> list[tuple[str, str]]:
         """Fetch and return tags matching the given`pattern`"""
         # See https://stackoverflow.com/a/65746233/374236
-        self._run("config --local extensions.partialClone true")
-        self._run(f"config --local http.userAgent '{http.ENDOFLIFE_BOT_USER_AGENT}'")
+        # The extensions.partialClone and http.userAgent settings only need to apply to this
+        # fetch, so they're passed as one-off `-c` overrides instead of persisted `git config`
+        # calls, saving two extra subprocess invocations.
         # Using --force to avoid error like "would clobber existing tag".
         # See https://stackoverflow.com/questions/58031165/how-to-get-rid-of-would-clobber-existing-tag.
-        self._run("fetch --force --tags --filter=blob:none --depth=1 origin")
-        tags_with_date = self._run("tag --list --format='%(refname:strip=2) %(creatordate:short)'")
+        self._run([
+            "-c", "extensions.partialClone=true",
+            "-c", f"http.userAgent={http.ENDOFLIFE_BOT_USER_AGENT}",
+            "fetch", "--force", "--tags", "--filter=blob:none", "--depth=1", "origin",
+        ])
+        tags_with_date = self._run(["tag", "--list", "--format=%(refname:strip=2) %(creatordate:short)"])
         return [tag_with_date.split(" ") for tag_with_date in tags_with_date]
 
     def list_branches(self, pattern: str) -> list[str]:
         """Uses ls-remote to fetch the branch names
         `pattern` uses fnmatch style globbing
         """
-        lines = self._run(f"ls-remote origin '{pattern}'")
+        lines = self._run(["ls-remote", "origin", pattern])
 
         # this checks keeps the linter quiet, because _run returns a bool OR list
         if isinstance(lines, bool):
@@ -67,6 +72,6 @@ class Git:
         """
         if file_list:
             # --skip-checks needed to avoid error when file_list contains a file
-            self._run(f"sparse-checkout set --skip-checks {' '.join(file_list)}")
-        self._run(f"fetch --filter=blob:none --depth 1 origin {branch}")
-        self._run(f"checkout {branch}")
+            self._run(["sparse-checkout", "set", "--skip-checks", *file_list])
+        self._run(["fetch", "--filter=blob:none", "--depth", "1", "origin", branch])
+        self._run(["checkout", branch])


### PR DESCRIPTION
- _run now execs `git` directly with an argument list instead of a shell string, avoiding an extra shell fork per invocation and fragile string-quoting for values with spaces (e.g. user agent).
- The two `git config --local` calls before fetching tags are replaced with one-off `-c` overrides passed directly to `git fetch`, removing two subprocess invocations per list_tags() call.