### PR TITLE
Improve logging

### DIFF
--- a/src/common/github.py
+++ b/src/common/github.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import subprocess
+import time
 
 
 class Release:
@@ -20,6 +21,7 @@ class Tag:
 def fetch_releases(repo_id: str) -> list[Release]:
     logging.info(f"fetching {repo_id} GitHub releases")
     (owner, repo) = repo_id.split('/')
+    start = time.perf_counter()
     child = subprocess.run("""gh api graphql --paginate -f query='
 query($endCursor: String) {
   repository(name: "%s", owner: "%s") {
@@ -40,7 +42,8 @@ query($endCursor: String) {
     }
   }
 }'""" % (repo, owner), capture_output=True, timeout=300, check=True, shell=True)  # noqa: UP031
-    logging.info(f"fetched {repo_id} GitHub releases")
+    elapsed = time.perf_counter() - start
+    logging.info(f"fetched {repo_id} GitHub releases, took {elapsed:.2f}s")
 
     # splitting because response may contain multiple JSON objects on a single line
     responses = child.stdout.decode("utf-8").strip().replace('}{', '}\n{').split("\n")
@@ -58,6 +61,7 @@ query($endCursor: String) {
 def fetch_tags(repo_id: str) -> list[Tag]:
     logging.info(f"fetching {repo_id} tags")
     (owner, repo) = repo_id.split('/')
+    start = time.perf_counter()
     child = subprocess.run("""gh api graphql --paginate -f query='
 query($endCursor: String) {
   repository(name: "%s", owner: "%s") {
@@ -78,7 +82,8 @@ query($endCursor: String) {
     }
   }
 }'""" % (repo, owner), capture_output=True, timeout=300, check=True, shell=True)  # noqa: UP031
-    logging.info(f"fetched {repo_id} tags")
+    elapsed = time.perf_counter() - start
+    logging.info(f"fetched {repo_id} tags, took {elapsed:.2f}s")
 
     responses = child.stdout.decode("utf-8").strip().replace('}{', '}\n{').split("\n")
     pages = [json.loads(response) for response in responses]

--- a/src/common/http.py
+++ b/src/common/http.py
@@ -1,4 +1,5 @@
 import logging
+import time
 import xml.dom.minidom
 from concurrent.futures import as_completed
 from xml.dom.minidom import Document
@@ -45,9 +46,12 @@ def fetch_urls(urls: list[str], data: any = None, user_agent: str = ENDOFLIFE_BO
     try:
         session = _FUTURES_SESSION
         headers = {'User-Agent': user_agent}
+        start = time.perf_counter()
         futures = [session.get(url, headers=headers, data=data, timeout=timeout, stream=None) for url in urls]
         results = [future.result() for future in as_completed(futures)]
-        logging.info(f"Fetched {urls}")
+        elapsed = time.perf_counter() - start
+        status_codes = [r.status_code for r in results]
+        logging.info(f"Fetched {urls}, took {elapsed:.2f}s, status={status_codes}")
         return results
     except ChunkedEncodingError as e:  # See https://github.com/psf/requests/issues/4771#issue-354077499
         next_remaining_retries = _remaining_retries - 1
@@ -101,8 +105,10 @@ def fetch_javascript_url(url: str, user_agent: str = ENDOFLIFE_BOT_USER_AGENT, h
 
         try:
             page = browser.new_page()
-            page.goto(url, wait_until=wait_until)
-            logging.info(f"Fetched {url}")
+            start = time.perf_counter()
+            response = page.goto(url, wait_until=wait_until)
+            elapsed = time.perf_counter() - start
+            logging.info(f"Fetched {url}, took {elapsed:.2f}s, status={response.status}")
 
             element_to_wait_for = None
             if wait_for:

--- a/src/common/releasedata.py
+++ b/src/common/releasedata.py
@@ -1,6 +1,7 @@
 import argparse
 import json
 import logging
+import os
 import sys
 from datetime import date, datetime, timezone
 from pathlib import Path
@@ -67,9 +68,9 @@ class ProductRelease:
         if old_value != new_value:
             self.data[field] = new_value
             if old_value:
-                logging.info(f"updated '{field}' in {self} from {old_value} to {new_value}")
+                logging.debug(f"updated '{field}' in {self} from {old_value} to {new_value}")
             else:
-                logging.info(f"set '{field}' in {self} to {new_value}")
+                logging.debug(f"set '{field}' in {self} to {new_value}")
 
 
     def get_field(self, field: str) -> any:
@@ -129,9 +130,9 @@ class ProductData:
                 for json_release in json_data.get("releases", {}).values():
                     release = ProductRelease(self.name, json_release)
                     self.releases[release.name()] = release
-            logging.info(f"loaded data for {self} from {self.path}")
+            logging.debug(f"loaded data for {self} from {self.path}")
         else:
-            logging.info(f"no data found for {self} at {self.path}")
+            logging.debug(f"no data found for {self} at {self.path}")
 
         return self
 
@@ -147,7 +148,7 @@ class ProductData:
             logging.error(message)
             raise ProductUpdateError(message)
 
-        logging.info("updating %s data", self.path)
+        logging.debug("updating %s data", self.path)
         ordered_releases = sorted(self.releases.values(), key=lambda v: v.name(), reverse=True)
         ordered_versions = sorted(self.versions.values(), key=lambda v: (v.date(), v.name()), reverse=True)
         with self.path.open("w") as f:
@@ -160,7 +161,7 @@ class ProductData:
         release_name = endoflife.to_identifier(release_name)
 
         if release_name not in self.releases:
-            logging.info(f"adding release {release_name} to {self}")
+            logging.debug(f"adding release {release_name} to {self}")
             self.releases[release_name] = ProductRelease.of(self.name, release_name)
 
         self.updated = True
@@ -174,7 +175,7 @@ class ProductData:
             logging.warning(f"release {release_name} cannot be removed as it does not exist for {self}")
             return
 
-        logging.info(f"removing release {release_name} ({self.releases.pop(release_name)}) from {self}: {reason}")
+        logging.debug(f"removing release {release_name} ({self.releases.pop(release_name)}) from {self}: {reason}")
         self.updated = True
 
     def get_version(self, version_name: str) -> ProductVersion:
@@ -189,10 +190,10 @@ class ProductData:
             return
 
         if version_name in self.versions and self.versions[version_name].date() != versions_date:
-            logging.info(f"overwriting {version_name} ({self.get_version(version_name).date()} -> {versions_date}) for {self}")
+            logging.debug(f"overwriting {version_name} ({self.get_version(version_name).date()} -> {versions_date}) for {self}")
             self.versions[version_name].replace_date(versions_date)
         else:
-            logging.info(f"adding version {version_name} ({versions_date}) to {self}")
+            logging.debug(f"adding version {version_name} ({versions_date}) to {self}")
             self.versions[version_name] = ProductVersion.of(self.name, version_name, versions_date)
 
     def remove_version(self, version_name: str) -> None:
@@ -200,7 +201,7 @@ class ProductData:
             logging.warning(f"version {version_name} cannot be removed as it does not exist for {self}")
             return
 
-        logging.info(f"removing version {version_name} ({self.versions.pop(version_name)}) from {self}")
+        logging.debug(f"removing version {version_name} ({self.versions.pop(version_name)}) from {self}")
 
     def __repr__(self) -> str:
         return self.name
@@ -214,11 +215,13 @@ def parse_argv(ignore_auto_config: bool = False) -> tuple[endoflife.ProductFront
     parser.add_argument('-p', '--product', required=True, help='path to the product')
     parser.add_argument('-m', '--method', required=True, help='method to filter by')
     parser.add_argument('-u', '--url', required=True, help='url to filter by')
-    parser.add_argument('-v', '--verbose', action='store_true', help='enable verbose logging')
+    parser.add_argument('-v', '--verbose', action='store_true',
+                        default=os.environ.get('ACTIONS_STEP_DEBUG') == 'true',
+                        help='enable verbose logging (automatically enabled when ACTIONS_STEP_DEBUG is set)')
     args = parser.parse_args()
 
     # Do not update the format: it's also used to declare groups in the GitHub Actions logs.
-    logging.basicConfig(format="%(message)s", level=(logging.DEBUG if args.verbose else logging.INFO))
+    logging.basicConfig(format="%(message)s", level=(logging.DEBUG if args.verbose else logging.INFO), stream=sys.stdout)
 
     product = endoflife.ProductFrontmatter(Path(args.product))
     auto_config = None if ignore_auto_config else product.auto_config(args.method, args.url)

--- a/update-release-data.py
+++ b/update-release-data.py
@@ -1,6 +1,7 @@
 import argparse
 import json
 import logging
+import os
 import subprocess
 import sys
 import time
@@ -82,7 +83,7 @@ def __delete_data(product: ProductFrontmatter) -> None:
         return
 
     release_data_path.unlink()
-    logging.info(f"deleted {release_data_path} before running scripts")
+    logging.debug(f"deleted {release_data_path} before running scripts")
 
 
 def __revert_data(product: ProductFrontmatter) -> None:
@@ -101,7 +102,7 @@ CHILD_SCRIPT_TIMEOUT_SECONDS = 300
 def __run_script(product: ProductFrontmatter, config: AutoConfig, summary: ScriptExecutionSummary) -> bool:
     script = SCRIPT_DIR / SRC_DIR / config.script
 
-    logging.info(f"start running {script} for {config}")
+    logging.info(f"start running {script.name} for {config}")
     start = time.perf_counter()
 
     # timeout is handled in child scripts; CHILD_SCRIPT_TIMEOUT_SECONDS is only a defensive fallback
@@ -119,7 +120,7 @@ def __run_script(product: ProductFrontmatter, config: AutoConfig, summary: Scrip
 
     summary.register(script.stem, product.name, elapsed_seconds, success)
     logging.log(logging.ERROR if not success else logging.INFO,
-                f"ran {script} for {config}, took {elapsed_seconds:.2f}s (success={success})")
+                f"ran {script.name} for {config}, took {elapsed_seconds:.2f}s (success={success})")
 
     return success
 
@@ -228,11 +229,13 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Update product releases.')
     parser.add_argument('product', nargs='?', help='restrict update to the given product')
     parser.add_argument('-p', '--product-dir', required=True, help='path to the product directory')
-    parser.add_argument('-v', '--verbose', action='store_true', help='enable verbose logging')
     parser.add_argument('-f', '--force', action='store_true', help='force update even if auto update is disabled')
+    parser.add_argument('-v', '--verbose', action='store_true',
+                        default=os.environ.get('ACTIONS_STEP_DEBUG') == 'true',
+                        help='enable verbose logging (automatically enabled when ACTIONS_STEP_DEBUG is set)')
     args = parser.parse_args()
 
-    logging.basicConfig(format=logging.BASIC_FORMAT, level=(logging.DEBUG if args.verbose else logging.INFO))
+    logging.basicConfig(format=logging.BASIC_FORMAT, level=(logging.DEBUG if args.verbose else logging.INFO), stream=sys.stdout)
     install_playwright()
 
     products_dir = Path(args.product_dir)


### PR DESCRIPTION
- Downgrade per-item mutation logs (set_field, add/remove release, add/remove/overwrite version, update data) from INFO to DEBUG,
- Route logging through sys.stdout so ::group::/::endgroup:: markers and log messages share the same stream, fixing GHA grouping,
- Treat ACTIONS_STEP_DEBUG=true as equivalent to -v via argparse default, so re-running a workflow in debug mode automatically enables debug logs,
- Show only script filename instead of full path in run/start/end logs,
- Add duration and HTTP status codes to fetch_urls, fetch_javascript_url,  fetch_releases, and fetch_tags log messages.