### PR TITLE
Modernize BeautifulSoup usage across codebase

### DIFF
--- a/src/apple.py
+++ b/src/apple.py
@@ -30,7 +30,7 @@ with ProductData(config.product) as product_data:
     responses = http.fetch_urls(URLS)
 
     for response in responses:
-        soup = BeautifulSoup(response.text, "html5lib")
+        soup = BeautifulSoup(response.text, features="html5lib")
         versions_table = soup.select_one("#tableWraper")
         versions_table = versions_table if versions_table else soup.select_one("table.gb-table")
 

--- a/src/atlassian_versions.py
+++ b/src/atlassian_versions.py
@@ -11,9 +11,9 @@ This script takes a single argument which is the url of the product's download-a
 config = config_from_argv()
 with ProductData(config.product) as product_data:
     content = http.fetch_javascript_url(config.url, wait_until='networkidle')
-    soup = BeautifulSoup(content, 'html5lib')
+    soup = BeautifulSoup(content, features='html5lib')
 
     for version_block in soup.select('.versions-list'):
-        version = version_block.select_one('a.product-versions').attrs['data-version']
+        version = version_block.select_one('a.product-versions')['data-version']
         date = dates.parse_date(version_block.select_one('.release-date').text)
         product_data.declare_version(version, date)

--- a/src/coldfusion.py
+++ b/src/coldfusion.py
@@ -11,9 +11,9 @@ VERSION_AND_DATE_PATTERN = re.compile(r"Release Date[,|:]? (.*?)\).*?Build Numbe
 
 config = config_from_argv()
 with ProductData(config.product) as product_data:
-    html = BeautifulSoup(http.fetch_javascript_url(config.url), "html5lib")
+    html = BeautifulSoup(http.fetch_javascript_url(config.url), features="html5lib")
 
-    for p in html.findAll("div", class_="text"):
+    for p in html.find_all("div", class_="text"):
         version_and_date_str = p.get_text().strip().replace('\xa0', ' ')
         for (date_str, version_str) in VERSION_AND_DATE_PATTERN.findall(version_and_date_str):
             date = dates.parse_date(date_str)

--- a/src/couchbase-server.py
+++ b/src/couchbase-server.py
@@ -10,7 +10,7 @@ config = config_from_argv()
 with ProductData(config.product) as product_data:
     html = http.fetch_html(f"{config.url}/current/release-notes/relnotes.html")
 
-    minor_versions = [options.attrs["value"] for options in html.find(class_="version_list").find_all("option")]
+    minor_versions = [options["value"] for options in html.find(class_="version_list").find_all("option")]
     minor_version_urls = [f"{config.url}/{minor}/release-notes/relnotes.html" for minor in minor_versions]
 
     for minor_version in http.fetch_urls(minor_version_urls):

--- a/src/discourse.py
+++ b/src/discourse.py
@@ -9,7 +9,7 @@ from common.releasedata import ProductData, config_from_argv
 
 config = config_from_argv()
 with ProductData(config.product) as product_data:
-    html = BeautifulSoup(http.fetch_javascript_url(config.url))
+    html = BeautifulSoup(http.fetch_javascript_url(config.url), features="html5lib")
 
     for topic in html.select("tr.topic-list-item"):
         title = topic.select_one("span.link-top-line").get_text(strip=True)

--- a/src/ibm-aix.py
+++ b/src/ibm-aix.py
@@ -4,7 +4,7 @@ from common.releasedata import ProductData, config_from_argv
 
 config = config_from_argv()
 with ProductData(config.product) as product_data:
-    html = BeautifulSoup(http.fetch_javascript_url(config.url, wait_for="table"), "html5lib")
+    html = BeautifulSoup(http.fetch_javascript_url(config.url, wait_for="table"), features="html5lib")
 
     for release_table in html.find_all("table"):
         for row in release_table.find_all("tr")[1:]:  # for all rows except the header

--- a/src/splunk.py
+++ b/src/splunk.py
@@ -35,7 +35,7 @@ config = config_from_argv()
 with (ProductData(config.product) as product_data):
     html = BeautifulSoup(http.fetch_javascript_url(config.url), features="html5lib")
 
-    all_versions = [option.attrs['value'] for option in html.select("select#version-select > option")]
+    all_versions = [option['value'] for option in html.select("select#version-select > option")]
     all_versions = [v for v in all_versions if v != "DataMonitoringAppPreview"]
 
     # Latest minor release notes contains release notes for all previous minor versions.


### PR DESCRIPTION
- Replace deprecated findAll with find_all (coldfusion.py)
- Add explicit features='html5lib' parser to discourse.py
- Standardize parser kwarg to features= in apple.py, atlassian_versions.py, coldfusion.py, ibm-aix.py
- Replace .attrs['key'] with direct ['key'] access in splunk.py, couchbase-server.py, atlassian_versions.py