### PR TITLE
[discourse] Attempt to fix discourse scraping by waiting for topic list

### DIFF
--- a/src/discourse.py
+++ b/src/discourse.py
@@ -9,7 +9,8 @@ from common.releasedata import ProductData, config_from_argv
 
 config = config_from_argv()
 with ProductData(config.product) as product_data:
-    html = BeautifulSoup(http.fetch_javascript_url(config.url), features="html5lib")
+    raw_html = http.fetch_javascript_url(config.url, wait_for="tr.topic-list-item")
+    html = BeautifulSoup(raw_html, features="html5lib")
 
     for topic in html.select("tr.topic-list-item"):
         title = topic.select_one("span.link-top-line").get_text(strip=True)


### PR DESCRIPTION
It works in local, but systematically fails on GHA with the following error:

```
2026-07-13T15:45:48.7188380Z ##[group]sonarqube-server
2026-07-13T15:45:48.7189527Z INFO:root:start running _copy_product_releases.py for sonarqube-server#_copy_product_releases()
2026-07-13T15:45:48.9335303Z INFO:root:ran _copy_product_releases.py for sonarqube-server#_copy_product_releases(), took 0.21s (success=True)
2026-07-13T15:45:48.9337286Z INFO:root:start running discourse.py for sonarqube-server#discourse(https://community.sonarsource.com/c/sq/releases/24)
2026-07-13T15:45:49.2803174Z Fetching https://community.sonarsource.com/c/sq/releases/24 with JavaScript (wait_until = None, wait_for = None, select_wait_for = False, click_selector = None)
2026-07-13T15:45:51.1791609Z Fetched https://community.sonarsource.com/c/sq/releases/24, took 1.44s, status=200
2026-07-13T15:45:51.3178722Z /home/runner/work/release-data/release-data/src/discourse.py:12: GuessedAtParserWarning: No parser was explicitly specified, so I'm using the best available HTML parser for this system ("html5lib"). This usually isn't a problem, but if you run this code on another system, or in a different virtual environment, it may use a different parser and behave differently.
2026-07-13T15:45:51.3180806Z
2026-07-13T15:45:51.3182006Z The code that caused this warning is on line 12 of the file /home/runner/work/release-data/release-data/src/discourse.py. To get rid of this warning, pass the additional argument 'features="html5lib"' to the BeautifulSoup constructor.
2026-07-13T15:45:51.3183321Z
2026-07-13T15:45:51.3183803Z   html = BeautifulSoup(http.fetch_javascript_url(config.url))
2026-07-13T15:45:51.7738664Z Traceback (most recent call last):
2026-07-13T15:45:51.7739626Z   File "/home/runner/work/release-data/release-data/src/discourse.py", line 21, in <module>
2026-07-13T15:45:51.7740516Z an unexpected error occurred while updating sonarqube-server data
2026-07-13T15:45:51.7741039Z Traceback (most recent call last):
2026-07-13T15:45:51.7741521Z   File "/home/runner/work/release-data/release-data/src/discourse.py", line 21, in <module>
2026-07-13T15:45:51.7742062Z     date_str = topic.select_one("td.activity").get("title").strip()
2026-07-13T15:45:51.7742475Z                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2026-07-13T15:45:51.7742824Z AttributeError: 'NoneType' object has no attribute 'get'
2026-07-13T15:45:51.7743261Z     date_str = topic.select_one("td.activity").get("title").strip()
2026-07-13T15:45:51.7743859Z                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2026-07-13T15:45:51.7744428Z AttributeError: 'NoneType' object has no attribute 'get'
2026-07-13T15:45:51.7744812Z
2026-07-13T15:45:51.7745617Z The above exception was the direct cause of the following exception:
2026-07-13T15:45:51.7745915Z
2026-07-13T15:45:51.7746028Z Traceback (most recent call last):
2026-07-13T15:45:51.7746516Z   File "/home/runner/work/release-data/release-data/src/discourse.py", line 11, in <module>
2026-07-13T15:45:51.7747026Z     with ProductData(config.product) as product_data:
2026-07-13T15:45:51.7747569Z   File "/home/runner/work/release-data/release-data/src/common/releasedata.py", line 144, in __exit__
2026-07-13T15:45:51.7748116Z     raise ProductUpdateError(message) from exc_value
2026-07-13T15:45:51.7748666Z common.releasedata.ProductUpdateError: an unexpected error occurred while updating sonarqube-server data
2026-07-13T15:45:51.9073418Z ERROR:root:ran discourse.py for sonarqube-server#discourse(https://community.sonarsource.com/c/sq/releases/24), took 2.97s (success=False)
2026-07-13T15:45:51.9152638Z WARNING:root:reverted changes in /home/runner/work/release-data/release-data/releases/sonarqube-server.json
2026-07-13T15:45:51.9154049Z ##[endgroup]
```