### PR TITLE
docs: add missing period to bullet item in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Common Release Data for various projects in a consistent and easy-to-parse forma
 
 * `filename` matches the corresponding filename in the [products/](https://github.com/endoflife-date/endoflife.date/tree/master/products) directory in the endoflife.date repository.
 * Top-level keys are version strings.
-* Non-stable versions are not included (nightly, beta, RC, etc.)
+* Non-stable versions are not included (nightly, beta, RC, etc.).
 * Values are release dates in the YYYY-MM-DD format
 * Wherever possible, dates are as per the release's timezone.
 


### PR DESCRIPTION
## Description
This PR fixes bullet point punctuation consistency in `README.md`.

## Details
Added missing trailing period to the non-stable versions bullet item in the format summary list.