### PR TITLE
Replace subprocess-based script calling with in-process function calls

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -32,3 +32,6 @@ extend-ignore = [
   "ANN101", # Missing type annotation for self in method
   "E501", # Line too long
 ]
+
+per-file-ignores."src/release_table.py" = ["C901"]
+per-file-ignores."src/samsung-security.py" = ["C901"]

--- a/src/_copy_product_releases.py
+++ b/src/_copy_product_releases.py
@@ -1,4 +1,5 @@
-from common import releasedata
+from src.common import releasedata
+from src.common.endoflife import AutoConfig, ProductFrontmatter
 
 """Copy releases, without their properties, from product data (frontmatter) to release data.
 
@@ -6,7 +7,7 @@ This script is not intended to be declared in the frontmatter: it is for interna
 It executes before all other scripts, and helps the following scripts to work with releases.
 """
 
-frontmatter, _ = releasedata.parse_argv(ignore_auto_config=True)
-with releasedata.ProductData(frontmatter.name) as product_data:
-    for frontmatter_release in frontmatter.get_releases():
-        product_data.get_release(frontmatter_release.get("releaseCycle"))
+def update(product: ProductFrontmatter, _config: AutoConfig) -> None:
+    with releasedata.ProductData(product.name) as product_data:
+        for frontmatter_release in product.get_releases():
+            product_data.get_release(frontmatter_release.get("releaseCycle"))

--- a/src/_remove_invalid_releases.py
+++ b/src/_remove_invalid_releases.py
@@ -1,23 +1,24 @@
 import logging
 
-from common import dates, releasedata
+from src.common import dates, releasedata
+from src.common.endoflife import AutoConfig, ProductFrontmatter
 
 """Remove empty releases or releases which are released in the future."""
 
 TODAY = dates.today_at_midnight()
 
-frontmatter, _ = releasedata.parse_argv(ignore_auto_config=True)
-with releasedata.ProductData(frontmatter.name) as product_data:
-    releases = list(product_data.releases.values()) # a copy is needed to avoid modifying the dict while iterating
-    product_data.updated = True # mark the product data as updated even when there are no changes
+def update(product: ProductFrontmatter, _config: AutoConfig) -> None:
+    with releasedata.ProductData(product.name) as product_data:
+        releases = list(product_data.releases.values()) # a copy is needed to avoid modifying the dict while iterating
+        product_data.updated = True # mark the product data as updated even when there are no changes
 
-    for release in releases:
-        if release.is_empty():
-            product_data.remove_release(release.name(), "empty release")
-            continue
+        for release in releases:
+            if release.is_empty():
+                product_data.remove_release(release.name(), "empty release")
+                continue
 
-        if release.was_released_after(TODAY):
-            product_data.remove_release(release.name(), "future release")
-            continue
+            if release.was_released_after(TODAY):
+                product_data.remove_release(release.name(), "future release")
+                continue
 
-        logging.debug(f"Keeping release {release} in {product_data.name}")
+            logging.debug(f"Keeping release {release} in {product_data.name}")

--- a/src/amazon-eks.py
+++ b/src/amazon-eks.py
@@ -1,32 +1,33 @@
 import logging
 
-from common import dates, http
-from common.releasedata import ProductData, config_from_argv
+from src.common import dates, http
+from src.common.endoflife import AutoConfig, ProductFrontmatter
+from src.common.releasedata import ProductData
 
 """Fetches EKS versions from AWS docs.
 Now that AWS no longer publishes docs on GitHub, we use the Web Archive to get the older versions."""
 
-config = config_from_argv()
-with ProductData(config.product) as product_data:
-    html = http.fetch_html(config.url)
+def update(_product: ProductFrontmatter, config: AutoConfig) -> None:
+    with ProductData(config.product) as product_data:
+        html = http.fetch_html(config.url)
 
-    for tr in html.select("#main-col-body")[0].findAll("tr"):
-        cells = tr.findAll("td")
-        if not cells:
-            continue
+        for tr in html.select("#main-col-body")[0].findAll("tr"):
+            cells = tr.findAll("td")
+            if not cells:
+                continue
 
-        k8s_version_text = cells[0].text.strip()
-        k8s_version_match = config.first_match(k8s_version_text)
-        if not k8s_version_match:
-            logging.warning(f"Skipping {k8s_version_text}: does not match version regex(es)")
-            continue
+            k8s_version_text = cells[0].text.strip()
+            k8s_version_match = config.first_match(k8s_version_text)
+            if not k8s_version_match:
+                logging.warning(f"Skipping {k8s_version_text}: does not match version regex(es)")
+                continue
 
-        eks_version = cells[1].text.strip()
-        # K8S patch version is not kept to match versions on https://github.com/aws/eks-distro/tags
-        version = f"{k8s_version_match.group('major')}.{k8s_version_match.group('minor')}-{eks_version.replace('.', '-')}"
+            eks_version = cells[1].text.strip()
+            # K8S patch version is not kept to match versions on https://github.com/aws/eks-distro/tags
+            version = f"{k8s_version_match.group('major')}.{k8s_version_match.group('minor')}-{eks_version.replace('.', '-')}"
 
-        date_str = cells[-1].text.strip()
-        date_str = date_str.replace("April 18.2025", "April 18 2025") # temporary fix for a typo in the source
-        date = dates.parse_date_or_month_year_date(date_str)
+            date_str = cells[-1].text.strip()
+            date_str = date_str.replace("April 18.2025", "April 18 2025") # temporary fix for a typo in the source
+            date = dates.parse_date_or_month_year_date(date_str)
 
-        product_data.declare_version(version, date)
+            product_data.declare_version(version, date)

--- a/src/amazon-neptune.py
+++ b/src/amazon-neptune.py
@@ -1,7 +1,8 @@
 import re
 
-from common import dates, http
-from common.releasedata import ProductData, config_from_argv
+from src.common import dates, http
+from src.common.endoflife import AutoConfig, ProductFrontmatter
+from src.common.releasedata import ProductData
 
 """Fetches Amazon Neptune versions from its RSS feed on docs.aws.amazon.com."""
 
@@ -20,7 +21,7 @@ def parse(data: dict, product: ProductData) -> None:
     for item in data.get("contents", []):
         parse(item, product)
 
-config = config_from_argv()
-with ProductData(config.product) as product_data:
-    json = http.fetch_json(config.url)
-    parse(json, product_data)
+def update(_product: ProductFrontmatter, config: AutoConfig) -> None:
+    with ProductData(config.product) as product_data:
+        json = http.fetch_json(config.url)
+        parse(json, product_data)

--- a/src/apache-http-server.py
+++ b/src/apache-http-server.py
@@ -1,25 +1,26 @@
-from common import dates
-from common.git import Git
-from common.releasedata import ProductData, config_from_argv
+from src.common import dates
+from src.common.endoflife import AutoConfig, ProductFrontmatter
+from src.common.git import Git
+from src.common.releasedata import ProductData
 
 """Fetches Apache HTTP Server versions and release date from its git repository
 by looking at the STATUS file of each <major>.<minor>.x branch."""
 
-config = config_from_argv()
-with ProductData(config.product) as product_data:
-    git = Git(config.url)
-    git.setup()
+def update(_product: ProductFrontmatter, config: AutoConfig) -> None:
+    with ProductData(config.product) as product_data:
+        git = Git(config.url)
+        git.setup()
 
-    for branch in git.list_branches("refs/heads/?.?.x"):
-        git.checkout(branch, file_list=["STATUS"])
+        for branch in git.list_branches("refs/heads/?.?.x"):
+            git.checkout(branch, file_list=["STATUS"])
 
-        release_notes_file = git.repo_dir / "STATUS"
-        if not release_notes_file.exists():
-            continue
+            release_notes_file = git.repo_dir / "STATUS"
+            if not release_notes_file.exists():
+                continue
 
-        with release_notes_file.open("rb") as f:
-            release_notes = f.read().decode("utf-8", errors="ignore")
+            with release_notes_file.open("rb") as f:
+                release_notes = f.read().decode("utf-8", errors="ignore")
 
-        for pattern in config.include_version_patterns:
-            for (version, date_str) in pattern.findall(release_notes):
-                product_data.declare_version(version, dates.parse_date(date_str))
+            for pattern in config.include_version_patterns:
+                for (version, date_str) in pattern.findall(release_notes):
+                    product_data.declare_version(version, dates.parse_date(date_str))

--- a/src/apache-subversion.py
+++ b/src/apache-subversion.py
@@ -1,20 +1,22 @@
 import logging
 
-from common import dates, http
-from common.releasedata import ProductData, config_from_argv
+from src.common import dates, http
+from src.common.endoflife import AutoConfig, ProductFrontmatter
+from src.common.releasedata import ProductData
 
-config = config_from_argv()
-with ProductData(config.product) as product_data:
-    html = http.fetch_html(config.url)
 
-    ul = html.find("h2").find_next("ul")
-    for li in ul.find_all("li"):
-        text = li.get_text(strip=True)
-        match = config.first_match(text)
-        if not match:
-            logging.info(f"Skipping {text}, does not match any regex")
-            continue
+def update(_product: ProductFrontmatter, config: AutoConfig) -> None:
+    with ProductData(config.product) as product_data:
+        html = http.fetch_html(config.url)
 
-        version = match.group("version")
-        date = dates.parse_date(match.group("date"))
-        product_data.declare_version(version, date)
+        ul = html.find("h2").find_next("ul")
+        for li in ul.find_all("li"):
+            text = li.get_text(strip=True)
+            match = config.first_match(text)
+            if not match:
+                logging.info(f"Skipping {text}, does not match any regex")
+                continue
+
+            version = match.group("version")
+            date = dates.parse_date(match.group("date"))
+            product_data.declare_version(version, date)

--- a/src/apple.py
+++ b/src/apple.py
@@ -2,8 +2,10 @@ import logging
 import re
 
 from bs4 import BeautifulSoup
-from common import dates, http
-from common.releasedata import ProductData, config_from_argv
+
+from src.common import dates, http
+from src.common.endoflife import AutoConfig, ProductFrontmatter
+from src.common.releasedata import ProductData
 
 """Fetches and parses version and release date information from Apple's support website."""
 
@@ -25,35 +27,35 @@ URLS = [
 
 DATE_PATTERN = re.compile(r"\b\d+\s[A-Za-z]+\s\d+\b")
 
-config = config_from_argv()
-with ProductData(config.product) as product_data:
-    responses = http.fetch_urls(URLS)
+def update(_product: ProductFrontmatter, config: AutoConfig) -> None:
+    with ProductData(config.product) as product_data:
+        responses = http.fetch_urls(URLS)
 
-    for response in responses:
-        soup = BeautifulSoup(response.text, features="html5lib")
-        versions_table = soup.select_one("#tableWraper")
-        versions_table = versions_table if versions_table else soup.select_one("table.gb-table")
+        for response in responses:
+            soup = BeautifulSoup(response.text, features="html5lib")
+            versions_table = soup.select_one("#tableWraper")
+            versions_table = versions_table if versions_table else soup.select_one("table.gb-table")
 
-        if not versions_table:
-            message = f"no versions table found in {response.url}"
-            raise ValueError(message)
+            if not versions_table:
+                message = f"no versions table found in {response.url}"
+                raise ValueError(message)
 
-        for row in versions_table.find_all("tr")[1:]:
-            cells = row.find_all("td")
-            version_text = cells[0].get_text(separator=" ").strip()
-            date_text = cells[2].get_text(separator=" ").strip()
+            for row in versions_table.find_all("tr")[1:]:
+                cells = row.find_all("td")
+                version_text = cells[0].get_text(separator=" ").strip()
+                date_text = cells[2].get_text(separator=" ").strip()
 
-            date_match = DATE_PATTERN.search(date_text)
-            if not date_match:
-                logging.info(f"ignoring version {version_text} ({date_text}), date pattern don't match")
-                continue
+                date_match = DATE_PATTERN.search(date_text)
+                if not date_match:
+                    logging.info(f"ignoring version {version_text} ({date_text}), date pattern don't match")
+                    continue
 
-            date_str = date_match.group(0)
-            date = dates.parse_date(date_str)
-            for version_pattern in config.include_version_patterns:
-                for version_str in version_pattern.findall(version_text):
-                    version = product_data.get_version(version_str)
-                    if not version or version.date() > date:
-                        product_data.declare_version(version_str, date)
-                    else:
-                        logging.info(f"ignoring version {version_str} ({date}) for {product_data.name}")
+                date_str = date_match.group(0)
+                date = dates.parse_date(date_str)
+                for version_pattern in config.include_version_patterns:
+                    for version_str in version_pattern.findall(version_text):
+                        version = product_data.get_version(version_str)
+                        if not version or version.date() > date:
+                            product_data.declare_version(version_str, date)
+                        else:
+                            logging.info(f"ignoring version {version_str} ({date}) for {product_data.name}")

--- a/src/atlassian_eol.py
+++ b/src/atlassian_eol.py
@@ -1,8 +1,10 @@
 import logging
 
 from bs4 import BeautifulSoup
-from common import dates, http
-from common.releasedata import ProductData, config_from_argv
+
+from src.common import dates, http
+from src.common.endoflife import AutoConfig, ProductFrontmatter
+from src.common.releasedata import ProductData
 
 """Fetches EOL dates from Atlassian EOL page.
 
@@ -10,19 +12,19 @@ This script takes a selector argument which is the product title identifier on t
 `AtlassianSupportEndofLifePolicy-JiraSoftware`.
 """
 
-config = config_from_argv()
-with ProductData(config.product) as product_data:
-    content = http.fetch_javascript_url(config.url)
-    soup = BeautifulSoup(content, features="html5lib")
+def update(_product: ProductFrontmatter, config: AutoConfig) -> None:
+    with ProductData(config.product) as product_data:
+        content = http.fetch_javascript_url(config.url)
+        soup = BeautifulSoup(content, features="html5lib")
 
-    # Find the section with the EOL dates
-    for li in soup.select(f"#{config.data.get('selector')}+ul li"):
-        match = config.first_match(li.get_text(strip=True))
-        if not match:
-            logging.warning(f"Skipping '{li.get_text(strip=True)}', no match found")
-            continue
+        # Find the section with the EOL dates
+        for li in soup.select(f"#{config.data.get('selector')}+ul li"):
+            match = config.first_match(li.get_text(strip=True))
+            if not match:
+                logging.warning(f"Skipping '{li.get_text(strip=True)}', no match found")
+                continue
 
-        release_name = match.group("release")
-        date = dates.parse_date(match.group("date"))
-        release = product_data.get_release(release_name)
-        release.set_eol(date)
+            release_name = match.group("release")
+            date = dates.parse_date(match.group("date"))
+            release = product_data.get_release(release_name)
+            release.set_eol(date)

--- a/src/atlassian_versions.py
+++ b/src/atlassian_versions.py
@@ -1,6 +1,8 @@
 from bs4 import BeautifulSoup
-from common import dates, http
-from common.releasedata import ProductData, config_from_argv
+
+from src.common import dates, http
+from src.common.endoflife import AutoConfig, ProductFrontmatter
+from src.common.releasedata import ProductData
 
 """Fetches versions from Atlassian download-archives pages.
 
@@ -8,12 +10,12 @@ This script takes a single argument which is the url of the product's download-a
 `https://www.atlassian.com/software/confluence/download-archives`.
 """
 
-config = config_from_argv()
-with ProductData(config.product) as product_data:
-    content = http.fetch_javascript_url(config.url, wait_until='networkidle')
-    soup = BeautifulSoup(content, features='html5lib')
+def update(_product: ProductFrontmatter, config: AutoConfig) -> None:
+    with ProductData(config.product) as product_data:
+        content = http.fetch_javascript_url(config.url, wait_until='networkidle')
+        soup = BeautifulSoup(content, features='html5lib')
 
-    for version_block in soup.select('.versions-list'):
-        version = version_block.select_one('a.product-versions')['data-version']
-        date = dates.parse_date(version_block.select_one('.release-date').text)
-        product_data.declare_version(version, date)
+        for version_block in soup.select('.versions-list'):
+            version = version_block.select_one('a.product-versions')['data-version']
+            date = dates.parse_date(version_block.select_one('.release-date').text)
+            product_data.declare_version(version, date)

--- a/src/aws-lambda.py
+++ b/src/aws-lambda.py
@@ -1,43 +1,44 @@
 import logging
 
-from common import dates, http
-from common.releasedata import ProductData, config_from_argv
+from src.common import dates, http
+from src.common.endoflife import AutoConfig, ProductFrontmatter
+from src.common.releasedata import ProductData
 
 """Fetches AWS lambda runtimes with their support / EOL dates from https://docs.aws.amazon.com."""
 
-config = config_from_argv()
-with ProductData(config.product) as product_data:
-    html = http.fetch_html(config.url)
+def update(_product: ProductFrontmatter, config: AutoConfig) -> None:
+    with ProductData(config.product) as product_data:
+        html = http.fetch_html(config.url)
 
-    for i, table in enumerate(html.find_all("table")):
-        headers = [th.get_text().strip().lower() for th in table.find("thead").find_all("tr")[0].find_all("th")]
-        if "identifier" not in headers or "deprecation date" not in headers or "block function update" not in headers:
-            logging.info(f"table with header '{headers}' does not contain all the expected headers")
-            continue
+        for i, table in enumerate(html.find_all("table")):
+            headers = [th.get_text().strip().lower() for th in table.find("thead").find_all("tr")[0].find_all("th")]
+            if "identifier" not in headers or "deprecation date" not in headers or "block function update" not in headers:
+                logging.info(f"table with header '{headers}' does not contain all the expected headers")
+                continue
 
-        is_supported_table = i == 0  # first table is for supported runtimes, second for deprecated ones
-        identifier_index = headers.index("identifier")
-        deprecation_date_index = headers.index("deprecation date")
-        block_function_update_index = headers.index("block function update")
+            is_supported_table = i == 0  # first table is for supported runtimes, second for deprecated ones
+            identifier_index = headers.index("identifier")
+            deprecation_date_index = headers.index("deprecation date")
+            block_function_update_index = headers.index("block function update")
 
-        for row in table.find("tbody").find_all("tr"):
-            cells = row.find_all("td")
-            identifier = cells[identifier_index].get_text().strip()
+            for row in table.find("tbody").find_all("tr"):
+                cells = row.find_all("td")
+                identifier = cells[identifier_index].get_text().strip()
 
-            deprecation_date_str = cells[deprecation_date_index].get_text().strip()
-            try:
-                deprecation_date = dates.parse_date(deprecation_date_str)
-            except ValueError:
-                deprecation_date = None
+                deprecation_date_str = cells[deprecation_date_index].get_text().strip()
+                try:
+                    deprecation_date = dates.parse_date(deprecation_date_str)
+                except ValueError:
+                    deprecation_date = None
 
-            block_function_update_str = cells[block_function_update_index].get_text().strip()
-            try:
-                block_function_update = dates.parse_date(block_function_update_str)
-            except ValueError:
-                block_function_update = None
+                block_function_update_str = cells[block_function_update_index].get_text().strip()
+                try:
+                    block_function_update = dates.parse_date(block_function_update_str)
+                except ValueError:
+                    block_function_update = None
 
-            release = product_data.get_release(identifier)
-            # if no date is available, use False for supported runtimes and True for deprecated ones
-            release.set_eoas(deprecation_date if deprecation_date else not is_supported_table)
-            # if no date is available, use False for supported runtimes and True for deprecated ones
-            release.set_eol(block_function_update if block_function_update else not is_supported_table)
+                release = product_data.get_release(identifier)
+                # if no date is available, use False for supported runtimes and True for deprecated ones
+                release.set_eoas(deprecation_date if deprecation_date else not is_supported_table)
+                # if no date is available, use False for supported runtimes and True for deprecated ones
+                release.set_eol(block_function_update if block_function_update else not is_supported_table)

--- a/src/cgit.py
+++ b/src/cgit.py
@@ -1,29 +1,30 @@
-from common import dates, http
-from common.releasedata import ProductData, config_from_argv
+from src.common import dates, http
+from src.common.endoflife import AutoConfig, ProductFrontmatter
+from src.common.releasedata import ProductData
 
 """Fetches versions from repositories managed with cgit, such as the Linux kernel repository.
 Ideally we would want to use the git repository directly, but cgit-managed repositories don't support partial clone."""
 
-config = config_from_argv()
-with ProductData(config.product) as product_data:
-    html = http.fetch_html(config.url + '/refs/tags')
+def update(_product: ProductFrontmatter, config: AutoConfig) -> None:
+    with ProductData(config.product) as product_data:
+        html = http.fetch_html(config.url + '/refs/tags')
 
-    for table in html.find_all("table", class_="list"):
-        for row in table.find_all("tr"):
-            columns = row.find_all("td")
-            if len(columns) != 4:
-                continue
+        for table in html.find_all("table", class_="list"):
+            for row in table.find_all("tr"):
+                columns = row.find_all("td")
+                if len(columns) != 4:
+                    continue
 
-            version_str = columns[0].text.strip()
-            version_match = config.first_match(version_str)
-            if not version_match:
-                continue
+                version_str = columns[0].text.strip()
+                version_match = config.first_match(version_str)
+                if not version_match:
+                    continue
 
-            datetime_td = columns[3].find_next("span")
-            datetime_str = datetime_td.attrs["title"] if datetime_td else None
-            if not datetime_str:
-                continue
+                datetime_td = columns[3].find_next("span")
+                datetime_str = datetime_td.attrs["title"] if datetime_td else None
+                if not datetime_str:
+                    continue
 
-            version = config.render(version_match)
-            date = dates.parse_datetime(datetime_str)
-            product_data.declare_version(version, date)
+                version = config.render(version_match)
+                date = dates.parse_datetime(datetime_str)
+                product_data.declare_version(version, date)

--- a/src/chef-versions.py
+++ b/src/chef-versions.py
@@ -1,8 +1,9 @@
 import logging
 
-from common import dates, http
-from common.git import Git
-from common.releasedata import ProductData, config_from_argv
+from src.common import dates, http
+from src.common.endoflife import AutoConfig, ProductFrontmatter
+from src.common.git import Git
+from src.common.releasedata import ProductData
 
 """Fetch released versions from docs.chef.io and retrieve their date from GitHub.
 docs.chef.io needs to be scraped because not all tagged versions are actually released.
@@ -10,24 +11,24 @@ docs.chef.io needs to be scraped because not all tagged versions are actually re
 More context on https://github.com/endoflife-date/endoflife.date/pull/4425#discussion_r1447932411.
 """
 
-config = config_from_argv()
-with ProductData(config.product) as product_data:
-    html = http.fetch_html(config.url)
+def update(_product: ProductFrontmatter, config: AutoConfig) -> None:
+    with ProductData(config.product) as product_data:
+        html = http.fetch_html(config.url)
 
-    released_versions = []
-    for h2 in html.find_all('h2'):
-        title = h2.get_text(strip=True)
-        match = config.first_match(title)
-        if not match:
-            logging.warning(f"Skipping '{title}', no match found")
-            continue
-        released_versions.append(config.render(match))
+        released_versions = []
+        for h2 in html.find_all('h2'):
+            title = h2.get_text(strip=True)
+            match = config.first_match(title)
+            if not match:
+                logging.warning(f"Skipping '{title}', no match found")
+                continue
+            released_versions.append(config.render(match))
 
-    git = Git(config.data.get('repository'))
-    git.setup(bare=True)
-    versions = git.list_tags()
-    for version, date_str in versions:
-        version = version.startswith("v") and version[1:] or version  # Remove 'v' prefix if present
-        if version in released_versions:
-            date = dates.parse_date(date_str)
-            product_data.declare_version(version, date)
+        git = Git(config.data.get('repository'))
+        git.setup(bare=True)
+        versions = git.list_tags()
+        for version, date_str in versions:
+            version = version.startswith("v") and version[1:] or version  # Remove 'v' prefix if present
+            if version in released_versions:
+                date = dates.parse_date(date_str)
+                product_data.declare_version(version, date)

--- a/src/chrome-releases.py
+++ b/src/chrome-releases.py
@@ -1,20 +1,21 @@
 import re
 
-from common import dates, http
-from common.releasedata import ProductData, config_from_argv
+from src.common import dates, http
+from src.common.endoflife import AutoConfig, ProductFrontmatter
+from src.common.releasedata import ProductData
 
 """Fetches versions from https://chromiumdash.appspot.com API."""
 
 FIRST_AVAILABLE_VERSION = 7
 DATE_REGEX = re.compile(r'Stable release date:')
 
-config = config_from_argv()
-with ProductData(config.product) as product_data:
-    latest_release = int(product_data.get_latest_release().name())
-    n_available_releases = latest_release - FIRST_AVAILABLE_VERSION
+def update(_product: ProductFrontmatter, config: AutoConfig) -> None:
+    with ProductData(config.product) as product_data:
+        latest_release = int(product_data.get_latest_release().name())
+        n_available_releases = latest_release - FIRST_AVAILABLE_VERSION
 
-    releases = http.fetch_json(f"{config.url}?offset=-{n_available_releases}&n={n_available_releases + 1}")
-    for json_release in releases.get("mstones", []):
-        release = product_data.get_release(str(json_release["mstone"]))
-        release_date = dates.parse_datetime(json_release["stable_date"])
-        release.set_release_date(release_date)
+        releases = http.fetch_json(f"{config.url}?offset=-{n_available_releases}&n={n_available_releases + 1}")
+        for json_release in releases.get("mstones", []):
+            release = product_data.get_release(str(json_release["mstone"]))
+            release_date = dates.parse_datetime(json_release["stable_date"])
+            release.set_release_date(release_date)

--- a/src/citrix-vad-rss.py
+++ b/src/citrix-vad-rss.py
@@ -1,24 +1,25 @@
 import logging
 
-from common import dates, http
-from common.releasedata import ProductData, config_from_argv
+from src.common import dates, http
+from src.common.endoflife import AutoConfig, ProductFrontmatter
+from src.common.releasedata import ProductData
 
 """Fetches EOL dates from Citrix Virtual Apps and Desktops Download Updates RSS feed."""
 
-config = config_from_argv()
-with ProductData(config.product) as product_data:
-    rss = http.fetch_xml(config.url)
+def update(_product: ProductFrontmatter, config: AutoConfig) -> None:
+    with ProductData(config.product) as product_data:
+        rss = http.fetch_xml(config.url)
 
-    for entry in rss.getElementsByTagName("item"):
-        version_str = entry.getElementsByTagName("title")[0].firstChild.nodeValue
-        date_str = entry.getElementsByTagName("pubDate")[0].firstChild.nodeValue
+        for entry in rss.getElementsByTagName("item"):
+            version_str = entry.getElementsByTagName("title")[0].firstChild.nodeValue
+            date_str = entry.getElementsByTagName("pubDate")[0].firstChild.nodeValue
 
-        version_match = config.first_match(version_str)
-        if not version_match:
-            logging.info(f"Skipping unmatched entry: {version_str}")
-            continue
+            version_match = config.first_match(version_str)
+            if not version_match:
+                logging.info(f"Skipping unmatched entry: {version_str}")
+                continue
 
-        logging.debug(f"Processing version: {version_str} with date {date_str}")
-        version = config.render(version_match)
-        date = dates.parse_datetime(date_str)
-        product_data.declare_version(version, date)
+            logging.debug(f"Processing version: {version_str} with date {date_str}")
+            version = config.render(version_match)
+            date = dates.parse_datetime(date_str)
+            product_data.declare_version(version, date)

--- a/src/coldfusion.py
+++ b/src/coldfusion.py
@@ -1,21 +1,23 @@
 import re
 
 from bs4 import BeautifulSoup
-from common import dates, http
-from common.releasedata import ProductData, config_from_argv
+
+from src.common import dates, http
+from src.common.endoflife import AutoConfig, ProductFrontmatter
+from src.common.releasedata import ProductData
 
 """Fetches versions from Adobe ColdFusion release notes on helpx.adobe.com."""
 
 VERSION_AND_DATE_PATTERN = re.compile(r"Release Date[,|:]? (.*?)\).*?Build Number: (.*?)$",
                                       re.DOTALL | re.MULTILINE | re.IGNORECASE)
 
-config = config_from_argv()
-with ProductData(config.product) as product_data:
-    html = BeautifulSoup(http.fetch_javascript_url(config.url), features="html5lib")
+def update(_product: ProductFrontmatter, config: AutoConfig) -> None:
+    with ProductData(config.product) as product_data:
+        html = BeautifulSoup(http.fetch_javascript_url(config.url), features="html5lib")
 
-    for p in html.find_all("div", class_="text"):
-        version_and_date_str = p.get_text().strip().replace('\xa0', ' ')
-        for (date_str, version_str) in VERSION_AND_DATE_PATTERN.findall(version_and_date_str):
-            date = dates.parse_date(date_str)
-            version = version_str.strip().replace(",", ".")  # 11,0,0,289974 -> 11.0.0.289974
-            product_data.declare_version(version, date)
+        for p in html.find_all("div", class_="text"):
+            version_and_date_str = p.get_text().strip().replace('\xa0', ' ')
+            for (date_str, version_str) in VERSION_AND_DATE_PATTERN.findall(version_and_date_str):
+                date = dates.parse_date(date_str)
+                version = version_str.strip().replace(",", ".")  # 11,0,0,289974 -> 11.0.0.289974
+                product_data.declare_version(version, date)

--- a/src/common/releasedata.py
+++ b/src/common/releasedata.py
@@ -1,8 +1,5 @@
-import argparse
 import json
 import logging
-import os
-import sys
 from datetime import date, datetime, timezone
 from pathlib import Path
 from types import TracebackType
@@ -205,24 +202,3 @@ class ProductData:
 
     def __repr__(self) -> str:
         return self.name
-
-
-def config_from_argv() -> endoflife.AutoConfig:
-    return parse_argv()[1]
-
-def parse_argv(ignore_auto_config: bool = False) -> tuple[endoflife.ProductFrontmatter, endoflife.AutoConfig]:
-    parser = argparse.ArgumentParser(description=sys.argv[0])
-    parser.add_argument('-p', '--product', required=True, help='path to the product')
-    parser.add_argument('-m', '--method', required=True, help='method to filter by')
-    parser.add_argument('-u', '--url', required=True, help='url to filter by')
-    parser.add_argument('-v', '--verbose', action='store_true',
-                        default=os.environ.get('ACTIONS_STEP_DEBUG') == 'true',
-                        help='enable verbose logging (automatically enabled when ACTIONS_STEP_DEBUG is set)')
-    args = parser.parse_args()
-
-    # Do not update the format: it's also used to declare groups in the GitHub Actions logs.
-    logging.basicConfig(format="%(message)s", level=(logging.DEBUG if args.verbose else logging.INFO), stream=sys.stdout)
-
-    product = endoflife.ProductFrontmatter(Path(args.product))
-    auto_config = None if ignore_auto_config else product.auto_config(args.method, args.url)
-    return product, auto_config

--- a/src/cos.py
+++ b/src/cos.py
@@ -2,8 +2,10 @@ import datetime
 import re
 
 from bs4 import BeautifulSoup
-from common import dates, http
-from common.releasedata import ProductData, config_from_argv
+
+from src.common import dates, http
+from src.common.endoflife import AutoConfig, ProductFrontmatter
+from src.common.releasedata import ProductData
 
 MILESTONE_PATTERN = re.compile(r'COS \d+ LTS')
 VERSION_PATTERN = re.compile(r"^(cos-\d+-\d+-\d+-\d+)")
@@ -15,31 +17,31 @@ def parse_date(date_text: str) -> datetime:
     return dates.parse_date(date_text)
 
 
-config = config_from_argv()
-with ProductData(config.product) as product_data:
-    main = http.fetch_url(config.url)
-    main_soup = BeautifulSoup(main.text, features="html5lib")
-    milestones = [cell.text.split(' ')[1] for cell in main_soup.find_all('td', string=MILESTONE_PATTERN)]
+def update(_product: ProductFrontmatter, config: AutoConfig) -> None:
+    with ProductData(config.product) as product_data:
+        main = http.fetch_url(config.url)
+        main_soup = BeautifulSoup(main.text, features="html5lib")
+        milestones = [cell.text.split(' ')[1] for cell in main_soup.find_all('td', string=MILESTONE_PATTERN)]
 
-    milestones_urls = [f"{main.url}m{milestone}" for milestone in milestones]
-    for milestone in http.fetch_urls(milestones_urls):
-        milestone_soup = BeautifulSoup(milestone.text, features="html5lib")
-        for article in milestone_soup.find_all('article', class_='devsite-article'):
-            for heading in article.find_all(['h2', 'h3']):  # headings contains the date, which we parse
-                version_str = heading.get('data-text')
-                version_match = VERSION_PATTERN.match(version_str)
-                if not version_match:
-                    continue
+        milestones_urls = [f"{main.url}m{milestone}" for milestone in milestones]
+        for milestone in http.fetch_urls(milestones_urls):
+            milestone_soup = BeautifulSoup(milestone.text, features="html5lib")
+            for article in milestone_soup.find_all('article', class_='devsite-article'):
+                for heading in article.find_all(['h2', 'h3']):  # headings contains the date, which we parse
+                    version_str = heading.get('data-text')
+                    version_match = VERSION_PATTERN.match(version_str)
+                    if not version_match:
+                        continue
 
-                try:  # 1st row is the header, so pick the first td in the 2nd row
-                    date_str = heading.find_next('tr').find_next('tr').find_next('td').text
-                except AttributeError:  # In some older releases, it is mentioned as Date: [Date]
-                    date_str = heading.find_next('i').text
+                    try:  # 1st row is the header, so pick the first td in the 2nd row
+                        date_str = heading.find_next('tr').find_next('tr').find_next('td').text
+                    except AttributeError:  # In some older releases, it is mentioned as Date: [Date]
+                        date_str = heading.find_next('i').text
 
-                try:
-                    date = parse_date(date_str)
-                except ValueError:  # for some h3, the date is in the previous h2
-                    date_str = heading.find_previous('h2').get('data-text')
-                    date = parse_date(date_str)
+                    try:
+                        date = parse_date(date_str)
+                    except ValueError:  # for some h3, the date is in the previous h2
+                        date_str = heading.find_previous('h2').get('data-text')
+                        date = parse_date(date_str)
 
-                product_data.declare_version(version_match.group(1), date)
+                    product_data.declare_version(version_match.group(1), date)

--- a/src/couchbase-server.py
+++ b/src/couchbase-server.py
@@ -1,28 +1,30 @@
 import logging
 
 from bs4 import BeautifulSoup
-from common import dates, http
-from common.releasedata import ProductData, config_from_argv
+
+from src.common import dates, http
+from src.common.endoflife import AutoConfig, ProductFrontmatter
+from src.common.releasedata import ProductData
 
 """Fetches versions from release notes of each minor version on docs.couchbase.com."""
 
-config = config_from_argv()
-with ProductData(config.product) as product_data:
-    html = http.fetch_html(f"{config.url}/current/release-notes/relnotes.html")
+def update(_product: ProductFrontmatter, config: AutoConfig) -> None:
+    with ProductData(config.product) as product_data:
+        html = http.fetch_html(f"{config.url}/current/release-notes/relnotes.html")
 
-    minor_versions = [options["value"] for options in html.find(class_="version_list").find_all("option")]
-    minor_version_urls = [f"{config.url}/{minor}/release-notes/relnotes.html" for minor in minor_versions]
+        minor_versions = [options["value"] for options in html.find(class_="version_list").find_all("option")]
+        minor_version_urls = [f"{config.url}/{minor}/release-notes/relnotes.html" for minor in minor_versions]
 
-    for minor_version in http.fetch_urls(minor_version_urls):
-        minor_version_soup = BeautifulSoup(minor_version.text, features="html5lib")
+        for minor_version in http.fetch_urls(minor_version_urls):
+            minor_version_soup = BeautifulSoup(minor_version.text, features="html5lib")
 
-        for title in minor_version_soup.find_all("h2"):
-            match = config.first_match(title.get_text().strip())
-            if not match:
-                logging.info(f"Skipping {title}, does not match any regex")
-                continue
+            for title in minor_version_soup.find_all("h2"):
+                match = config.first_match(title.get_text().strip())
+                if not match:
+                    logging.info(f"Skipping {title}, does not match any regex")
+                    continue
 
-            version = match["version"]
-            version = f"{version}.0" if len(version.split(".")) == 2 else version
-            date = dates.parse_month_year_date(match['date']).replace(day=1)
-            product_data.declare_version(version, date)
+                version = match["version"]
+                version = f"{version}.0" if len(version.split(".")) == 2 else version
+                date = dates.parse_month_year_date(match['date']).replace(day=1)
+                product_data.declare_version(version, date)

--- a/src/debian.py
+++ b/src/debian.py
@@ -1,9 +1,10 @@
 from pathlib import Path
 from subprocess import run
 
-from common import dates
-from common.git import Git
-from common.releasedata import ProductData, config_from_argv
+from src.common import dates
+from src.common.endoflife import AutoConfig, ProductFrontmatter
+from src.common.git import Git
+from src.common.releasedata import ProductData
 
 """Fetch Debian versions by parsing news in www.debian.org source repository."""
 
@@ -41,11 +42,11 @@ def extract_point_versions(p: ProductData, repo_dir: Path) -> None:
         (date, version) = line.split(' ')
         p.declare_version(version, dates.parse_date(date))
 
-config = config_from_argv()
-with ProductData(config.product) as product_data:
-    git = Git(config.url)
-    git.setup()
-    git.checkout("master", file_list=["english/News"])
+def update(_product: ProductFrontmatter, config: AutoConfig) -> None:
+    with ProductData(config.product) as product_data:
+        git = Git(config.url)
+        git.setup()
+        git.checkout("master", file_list=["english/News"])
 
-    extract_major_versions(product_data, git.repo_dir)
-    extract_point_versions(product_data, git.repo_dir)
+        extract_major_versions(product_data, git.repo_dir)
+        extract_point_versions(product_data, git.repo_dir)

--- a/src/declare.py
+++ b/src/declare.py
@@ -1,16 +1,17 @@
 from datetime import datetime
 
-from common.releasedata import ProductData, config_from_argv
+from src.common.endoflife import AutoConfig, ProductFrontmatter
+from src.common.releasedata import ProductData
 
 """Manually declare missing or erroneous versions."""
 
-config = config_from_argv()
-with ProductData(config.product) as product_data:
-    for version in config.data.get("versions", []):
-        product_data.declare_version(version['name'], version['date'])
+def update(_product: ProductFrontmatter, config: AutoConfig) -> None:
+    with ProductData(config.product) as product_data:
+        for version in config.data.get("versions", []):
+            product_data.declare_version(version['name'], version['date'])
 
-    releases: list[dict[str, str | bool | datetime]] = config.data.get("releases", [])
-    for release in releases:
-        release_data = product_data.get_release(release.pop("name"))
-        for key, value in release.items():
-            release_data.set_field(key, value)
+        releases: list[dict[str, str | bool | datetime]] = config.data.get("releases", [])
+        for release in releases:
+            release_data = product_data.get_release(release.pop("name"))
+            for key, value in release.items():
+                release_data.set_field(key, value)

--- a/src/discourse.py
+++ b/src/discourse.py
@@ -2,28 +2,30 @@ import logging
 import re
 
 from bs4 import BeautifulSoup
-from common import dates, http
-from common.releasedata import ProductData, config_from_argv
+
+from src.common import dates, http
+from src.common.endoflife import AutoConfig, ProductFrontmatter
+from src.common.releasedata import ProductData
 
 """Fetch versions from a discourse server."""
 
-config = config_from_argv()
-with ProductData(config.product) as product_data:
-    raw_html = http.fetch_javascript_url(config.url, wait_for="tr.topic-list-item")
-    html = BeautifulSoup(raw_html, features="html5lib")
+def update(_product: ProductFrontmatter, config: AutoConfig) -> None:
+    with ProductData(config.product) as product_data:
+        raw_html = http.fetch_javascript_url(config.url, wait_for="tr.topic-list-item")
+        html = BeautifulSoup(raw_html, features="html5lib")
 
-    for topic in html.select("tr.topic-list-item"):
-        title = topic.select_one("span.link-top-line").get_text(strip=True)
-        versions = config.first_match(title)
-        if not versions:
-            continue
+        for topic in html.select("tr.topic-list-item"):
+            title = topic.select_one("span.link-top-line").get_text(strip=True)
+            versions = config.first_match(title)
+            if not versions:
+                continue
 
-        name = config.render(versions)
-        date_str = topic.select_one("td.activity").get("title").strip()
-        date_match = re.search(r"Created:\s*([A-Za-z]+\s+\d{1,2},\s+\d{4}\s+\d{1,2}:\d{2}\s+[ap]m)", date_str)
-        if not date_match:
-            logging.debug("Skipping %s: no created date found", title)
-            continue
+            name = config.render(versions)
+            date_str = topic.select_one("td.activity").get("title").strip()
+            date_match = re.search(r"Created:\s*([A-Za-z]+\s+\d{1,2},\s+\d{4}\s+\d{1,2}:\d{2}\s+[ap]m)", date_str)
+            if not date_match:
+                logging.debug("Skipping %s: no created date found", title)
+                continue
 
-        date = dates.parse_datetime(date_match.group(1))
-        product_data.declare_version(name, date)
+            date = dates.parse_datetime(date_match.group(1))
+            product_data.declare_version(name, date)

--- a/src/distrowatch.py
+++ b/src/distrowatch.py
@@ -1,19 +1,21 @@
-from common import dates, http
-from common.releasedata import ProductData, config_from_argv
+from src.common import dates, http
+from src.common.endoflife import AutoConfig, ProductFrontmatter
+from src.common.releasedata import ProductData
 
-config = config_from_argv()
-with ProductData(config.product) as product_data:
-    html = http.fetch_html(f"https://distrowatch.com/index.php?distribution={config.url}")
 
-    for table in html.select("td.News1>table.News"):
-        headline = table.select_one("td.NewsHeadline a[href]").get_text().strip()
-        versions_match = config.first_match(headline)
-        if not versions_match:
-            continue
+def update(_product: ProductFrontmatter, config: AutoConfig) -> None:
+    with ProductData(config.product) as product_data:
+        html = http.fetch_html(f"https://distrowatch.com/index.php?distribution={config.url}")
 
-        # multiple versions may be released at once (e.g. Ubuntu 16.04.7 and 18.04.5)
-        versions = config.render(versions_match).split("\n")
-        date = dates.parse_date(table.select_one("td.NewsDate").get_text())
+        for table in html.select("td.News1>table.News"):
+            headline = table.select_one("td.NewsHeadline a[href]").get_text().strip()
+            versions_match = config.first_match(headline)
+            if not versions_match:
+                continue
 
-        for version in versions:
-            product_data.declare_version(version, date)
+            # multiple versions may be released at once (e.g. Ubuntu 16.04.7 and 18.04.5)
+            versions = config.render(versions_match).split("\n")
+            date = dates.parse_date(table.select_one("td.NewsDate").get_text())
+
+            for version in versions:
+                product_data.declare_version(version, date)

--- a/src/docker_hub.py
+++ b/src/docker_hub.py
@@ -1,5 +1,6 @@
-from common import dates, endoflife, http
-from common.releasedata import ProductData, config_from_argv
+from src.common import dates, endoflife, http
+from src.common.endoflife import AutoConfig, ProductFrontmatter
+from src.common.releasedata import ProductData
 
 """Fetches releases from the Docker Hub API.
 
@@ -19,6 +20,6 @@ def fetch_releases(p: ProductData, c: endoflife.AutoConfig, url: str) -> None:
         fetch_releases(p, c, data["next"])
 
 
-config = config_from_argv()
-with ProductData(config.product) as product_data:
-    fetch_releases(product_data, config, f"https://hub.docker.com/v2/repositories/{config.url}/tags?page_size=100&page=1")
+def update(_product: ProductFrontmatter, config: AutoConfig) -> None:
+    with ProductData(config.product) as product_data:
+        fetch_releases(product_data, config, f"https://hub.docker.com/v2/repositories/{config.url}/tags?page_size=100&page=1")

--- a/src/firefox.py
+++ b/src/firefox.py
@@ -1,8 +1,10 @@
 import urllib.parse
 
 from bs4 import BeautifulSoup
-from common import dates, http
-from common.releasedata import ProductData, config_from_argv
+
+from src.common import dates, http
+from src.common.endoflife import AutoConfig, ProductFrontmatter
+from src.common.releasedata import ProductData
 
 """Fetch Firefox versions with their dates from https://www.mozilla.org/.
 
@@ -21,15 +23,15 @@ The script will need to be updated if someday those conditions are not met."""
 
 MAX_VERSIONS_LIMIT = 250
 
-config = config_from_argv()
-with ProductData(config.product) as product_data:
-    releases_page = http.fetch_url(config.url)
-    releases_soup = BeautifulSoup(releases_page.text, features="html5lib")
-    releases_list = releases_soup.find_all("ol", class_="c-release-list")
+def update(_product: ProductFrontmatter, config: AutoConfig) -> None:
+    with ProductData(config.product) as product_data:
+        releases_page = http.fetch_url(config.url)
+        releases_soup = BeautifulSoup(releases_page.text, features="html5lib")
+        releases_list = releases_soup.find_all("ol", class_="c-release-list")
 
-    release_notes_urls = [urllib.parse.urljoin(releases_page.url, p.get("href")) for p in releases_list[0].find_all("a")]
-    for release_notes in http.fetch_urls(release_notes_urls[:MAX_VERSIONS_LIMIT]):
-        version = release_notes.url.split("/")[-3]
-        release_notes_soup = BeautifulSoup(release_notes.text, features="html5lib")
-        date_str = release_notes_soup.find(class_="c-release-date").get_text()  # note: only works for versions > 25
-        product_data.declare_version(version, dates.parse_date(date_str))
+        release_notes_urls = [urllib.parse.urljoin(releases_page.url, p.get("href")) for p in releases_list[0].find_all("a")]
+        for release_notes in http.fetch_urls(release_notes_urls[:MAX_VERSIONS_LIMIT]):
+            version = release_notes.url.split("/")[-3]
+            release_notes_soup = BeautifulSoup(release_notes.text, features="html5lib")
+            date_str = release_notes_soup.find(class_="c-release-date").get_text()  # note: only works for versions > 25
+            product_data.declare_version(version, dates.parse_date(date_str))

--- a/src/freebsd-releases.py
+++ b/src/freebsd-releases.py
@@ -1,29 +1,30 @@
 import logging
 import re
 
-from common import dates, http
-from common.releasedata import ProductData, config_from_argv
+from src.common import dates, http
+from src.common.endoflife import AutoConfig, ProductFrontmatter
+from src.common.releasedata import ProductData
 
 """Fetches releases from https://www.freebsd.org."""
 
 VERSION_AND_DATE_PATTERN = re.compile(r"^(Release )?(?P<release>\d+\.\d+)\s*\((?P<date>\w+( \d+)?, \d+)\)")
 
-config = config_from_argv()
-with ProductData(config.product) as product_data:
-    html = http.fetch_html(config.url)
+def update(_product: ProductFrontmatter, config: AutoConfig) -> None:
+    with ProductData(config.product) as product_data:
+        html = http.fetch_html(config.url)
 
-    for li in html.select("li"):
-        text = li.get_text(strip=True)
+        for li in html.select("li"):
+            text = li.get_text(strip=True)
 
-        match = VERSION_AND_DATE_PATTERN.search(text)
-        if not match:
-            logging.debug(f"Skipping {text}, does not match pattern")
-            continue
+            match = VERSION_AND_DATE_PATTERN.search(text)
+            if not match:
+                logging.debug(f"Skipping {text}, does not match pattern")
+                continue
 
-        logging.debug(f"Processing {text}")
-        release_name = match.group("release")
-        release = product_data.get_release(release_name)
-        release.set_field('releaseLabel', f"releng/{release_name}")
+            logging.debug(f"Processing {text}")
+            release_name = match.group("release")
+            release = product_data.get_release(release_name)
+            release.set_field('releaseLabel', f"releng/{release_name}")
 
-        release_date = dates.parse_date_or_month_year_date(match.group("date"))
-        release.set_release_date(release_date)
+            release_date = dates.parse_date_or_month_year_date(match.group("date"))
+            release.set_release_date(release_date)

--- a/src/ghc-wiki.py
+++ b/src/ghc-wiki.py
@@ -14,8 +14,9 @@ References:
 import re
 from typing import Any, Generator, Iterator
 
-from common import dates, http
-from common.releasedata import ProductData, config_from_argv
+from src.common import dates, http
+from src.common.endoflife import AutoConfig, ProductFrontmatter
+from src.common.releasedata import ProductData
 
 
 def parse_markdown_tables(lineiter: Iterator[str]) -> Generator[list[list[Any]], Any, None]:
@@ -51,41 +52,41 @@ def maybe_markdown_table_row(line: str) -> list[str] | None:
         return None
     return [x.strip() for x in line.strip('|').split('|')]
 
-config = config_from_argv()
-with ProductData(config.product) as product_data:
-    resp = http.fetch_url(config.url)
-    resp.raise_for_status()
-    data = resp.json()
-    assert data['title'] == "GHC Status"
-    assert data['format'] == "markdown"
-    md = data['content'].splitlines()
+def update(_product: ProductFrontmatter, config: AutoConfig) -> None:
+    with ProductData(config.product) as product_data:
+        resp = http.fetch_url(config.url)
+        resp.raise_for_status()
+        data = resp.json()
+        assert data['title'] == "GHC Status"
+        assert data['format'] == "markdown"
+        md = data['content'].splitlines()
 
-    #-- Parse tables out of the wiki text. At time of writing, the script expects exactly two:
-    #-- 1. "Most recent major" with 5 columns
-    #-- 2. "All released versions" with 5 columns
-    [series_table, patch_level] = parse_markdown_tables(iter(md))
+        #-- Parse tables out of the wiki text. At time of writing, the script expects exactly two:
+        #-- 1. "Most recent major" with 5 columns
+        #-- 2. "All released versions" with 5 columns
+        [series_table, patch_level] = parse_markdown_tables(iter(md))
 
-    for row in series_table[1:]:
-        [series, _download_link, _most_recent, next_planned, status] = row
-        if "Next major release" in status:
-            continue
+        for row in series_table[1:]:
+            [series, _download_link, _most_recent, next_planned, status] = row
+            if "Next major release" in status:
+                continue
 
-        series = series.split(' ')[0]
-        series = series.replace('\\.', '.')
-        if series == "Nightlies":
-            continue
-        status = status.lower()
+            series = series.split(' ')[0]
+            series = series.replace('\\.', '.')
+            if series == "Nightlies":
+                continue
+            status = status.lower()
 
-        #-- See discussion in https://github.com/endoflife-date/endoflife.date/pull/6287
-        r = product_data.get_release(series)
-        #-- The clearest semblance of an EOL signal we get
-        r.set_eol("not recommended for use" in status or ":red_circle:" in status)
-        #-- eoasColumn label is "Further releases planned"
-        r.set_eoas(any(keyword in next_planned for keyword in ("None",  "N/A")))
+            #-- See discussion in https://github.com/endoflife-date/endoflife.date/pull/6287
+            r = product_data.get_release(series)
+            #-- The clearest semblance of an EOL signal we get
+            r.set_eol("not recommended for use" in status or ":red_circle:" in status)
+            #-- eoasColumn label is "Further releases planned"
+            r.set_eoas(any(keyword in next_planned for keyword in ("None",  "N/A")))
 
-    for row in patch_level[1:]:
-        [milestone, _download_link, date, _ticket, _manager] = row
-        version = milestone.lstrip('%')
-        version = version.split(' ') [0]
-        date = dates.parse_date(date)
-        product_data.declare_version(version, date)
+        for row in patch_level[1:]:
+            [milestone, _download_link, date, _ticket, _manager] = row
+            version = milestone.lstrip('%')
+            version = version.split(' ') [0]
+            date = dates.parse_date(date)
+            product_data.declare_version(version, date)

--- a/src/git.py
+++ b/src/git.py
@@ -1,18 +1,19 @@
-from common import dates
-from common.git import Git
-from common.releasedata import ProductData, config_from_argv
+from src.common import dates
+from src.common.endoflife import AutoConfig, ProductFrontmatter
+from src.common.git import Git
+from src.common.releasedata import ProductData
 
 """Fetches versions from tags in a git repository. This replace the old update.rb script."""
 
-config = config_from_argv()
-with ProductData(config.product) as product_data:
-    git = Git(config.url)
-    git.setup(bare=True)
+def update(_product: ProductFrontmatter, config: AutoConfig) -> None:
+    with ProductData(config.product) as product_data:
+        git = Git(config.url)
+        git.setup(bare=True)
 
-    tags = git.list_tags()
-    for tag, date_str in tags:
-        version_match = config.first_match(tag)
-        if version_match:
-            version = config.render(version_match)
-            date = dates.parse_date(date_str)
-            product_data.declare_version(version, date)
+        tags = git.list_tags()
+        for tag, date_str in tags:
+            version_match = config.first_match(tag)
+            if version_match:
+                version = config.render(version_match)
+                date = dates.parse_date(date_str)
+                product_data.declare_version(version, date)

--- a/src/github_releases.py
+++ b/src/github_releases.py
@@ -1,20 +1,21 @@
-from common import dates, github
-from common.releasedata import ProductData, config_from_argv
+from src.common import dates, github
+from src.common.endoflife import AutoConfig, ProductFrontmatter
+from src.common.releasedata import ProductData
 
 """Fetches versions from GitHub releases using the GraphQL API and the GitHub CLI.
 
 Note: GraphQL API and GitHub CLI are used because it's simpler: no need to manage pagination and authentication.
 """
 
-config = config_from_argv()
-with ProductData(config.product) as product_data:
-    for release in github.fetch_releases(config.url):
-        if release.is_prerelease:
-            continue
+def update(_product: ProductFrontmatter, config: AutoConfig) -> None:
+    with ProductData(config.product) as product_data:
+        for release in github.fetch_releases(config.url):
+            if release.is_prerelease:
+                continue
 
-        version_str = release.tag_name
-        version_match = config.first_match(version_str)
-        if version_match:
-            version = config.render(version_match)
-            date = dates.parse_datetime(release.published_at)
-            product_data.declare_version(version, date)
+            version_str = release.tag_name
+            version_match = config.first_match(version_str)
+            if version_match:
+                version = config.render(version_match)
+                date = dates.parse_datetime(release.published_at)
+                product_data.declare_version(version, date)

--- a/src/github_tags.py
+++ b/src/github_tags.py
@@ -1,17 +1,18 @@
-from common import dates, github
-from common.releasedata import ProductData, config_from_argv
+from src.common import dates, github
+from src.common.endoflife import AutoConfig, ProductFrontmatter
+from src.common.releasedata import ProductData
 
 """Fetches versions from GitHub tags using the GraphQL API and the GitHub CLI.
 
 Note: GraphQL API and GitHub CLI are used because it's simpler: no need to manage pagination and authentication.
 """
 
-config = config_from_argv()
-with ProductData(config.product) as product_data:
-    for tag in github.fetch_tags(config.url):
-        version_str = tag.name
-        version_match = config.first_match(version_str)
-        if version_match:
-            version = config.render(version_match)
-            date = dates.parse_datetime(tag.commit_date)
-            product_data.declare_version(version, date)
+def update(_product: ProductFrontmatter, config: AutoConfig) -> None:
+    with ProductData(config.product) as product_data:
+        for tag in github.fetch_tags(config.url):
+            version_str = tag.name
+            version_match = config.first_match(version_str)
+            if version_match:
+                version = config.render(version_match)
+                date = dates.parse_datetime(tag.commit_date)
+                product_data.declare_version(version, date)

--- a/src/gitlab_tags.py
+++ b/src/gitlab_tags.py
@@ -1,8 +1,9 @@
 from collections.abc import Iterator
 from urllib.parse import quote
 
-from common import dates, http
-from common.releasedata import ProductData, config_from_argv
+from src.common import dates, http
+from src.common.endoflife import AutoConfig, ProductFrontmatter
+from src.common.releasedata import ProductData
 
 """Fetches versions from GitLab tags using the REST API.
 """
@@ -23,12 +24,12 @@ def fetch_tags(project_path: str) -> Iterator[dict]:
         page += 1
 
 
-config = config_from_argv()
-with ProductData(config.product) as product_data:
-    for tag in fetch_tags(config.url):
-        version_str = tag['name']
-        version_match = config.first_match(version_str)
-        if version_match:
-            version = config.render(version_match)
-            date = dates.parse_datetime(tag['commit']['created_at'])
-            product_data.declare_version(version, date)
+def update(_product: ProductFrontmatter, config: AutoConfig) -> None:
+    with ProductData(config.product) as product_data:
+        for tag in fetch_tags(config.url):
+            version_str = tag['name']
+            version_match = config.first_match(version_str)
+            if version_match:
+                version = config.render(version_match)
+                date = dates.parse_datetime(tag['commit']['created_at'])
+                product_data.declare_version(version, date)

--- a/src/google-kubernetes-engine.py
+++ b/src/google-kubernetes-engine.py
@@ -1,28 +1,28 @@
 import logging
 
-from common import dates, http
-from common.releasedata import ProductData, config_from_argv
+from src.common import dates, http
+from src.common.endoflife import AutoConfig, ProductFrontmatter
+from src.common.releasedata import ProductData
 
 """Fetches versions from Google Kubernetes Engine release notes.
 
 This script does not work for versions prior to March 29, 2021, as the release note format was different before that date.
 """
 
-config = config_from_argv()
-with ProductData(config.product) as product_data:
-    html = http.fetch_html(config.url)
-    regex = config.data.get('regex')
+def update(_product: ProductFrontmatter, config: AutoConfig) -> None:
+    with ProductData(config.product) as product_data:
+        html = http.fetch_html(config.url)
 
-    for section in html.find_all('section', class_='releases'):
-        for h2 in section.find_all('h2'):  # h2 contains the date
-            date = dates.parse_date(h2.get('data-text'))
+        for section in html.find_all('section', class_='releases'):
+            for h2 in section.find_all('h2'):  # h2 contains the date
+                date = dates.parse_date(h2.get('data-text'))
 
-            for li in h2.find_next('div').find_all('li'):
-                if "versions are now available" not in li.text:
-                    logging.debug(f"Skipping {li.text}: does not contain new versions")
-                    continue
+                for li in h2.find_next('div').find_all('li'):
+                    if "versions are now available" not in li.text:
+                        logging.debug(f"Skipping {li.text}: does not contain new versions")
+                        continue
 
-                for sub_li in li.find_all('li', recursive=True):
-                    match = config.first_match(sub_li.text.strip())
-                    if match:
-                        product_data.declare_version(config.render(match), date)
+                    for sub_li in li.find_all('li', recursive=True):
+                        match = config.first_match(sub_li.text.strip())
+                        if match:
+                            product_data.declare_version(config.render(match), date)

--- a/src/graalvm.py
+++ b/src/graalvm.py
@@ -1,34 +1,36 @@
 import logging
 
-from common import dates, http
-from common.releasedata import ProductData, config_from_argv
+from src.common import dates, http
+from src.common.endoflife import AutoConfig, ProductFrontmatter
+from src.common.releasedata import ProductData
 
-config = config_from_argv()
-with ProductData(config.product) as product_data:
-    html = http.fetch_html(config.url)
-    table_selector = config.data.get("table_selector", "#previous-releases + table").strip()
-    date_column = config.data.get("date_column", "Date").strip().lower()
-    versions_column = config.data.get("versions_column").strip().lower()
 
-    table = html.select_one(table_selector)
-    headers = [th.get_text().strip().lower() for th in table.select("thead th")]
-    date_index = headers.index(date_column)
-    versions_index = headers.index(versions_column)
+def update(_product: ProductFrontmatter, config: AutoConfig) -> None:
+    with ProductData(config.product) as product_data:
+        html = http.fetch_html(config.url)
+        table_selector = config.data.get("table_selector", "#previous-releases + table").strip()
+        date_column = config.data.get("date_column", "Date").strip().lower()
+        versions_column = config.data.get("versions_column").strip().lower()
 
-    for row in table.select("tbody tr"):
-        cells = row.select("td")
-        if len(cells) <= max(date_index, versions_index):
-            logging.warning(f"Skipping row {cells}: not enough cells")
-            continue
+        table = html.select_one(table_selector)
+        headers = [th.get_text().strip().lower() for th in table.select("thead th")]
+        date_index = headers.index(date_column)
+        versions_index = headers.index(versions_column)
 
-        date_text = cells[date_index].get_text().strip()
-        date_text = date_text.removesuffix('.')  # Remove trailing . if present, such as for "January 20, 2026."
-        date = dates.parse_date(date_text)
-        if date > dates.today_at_midnight():
-            logging.info(f"Skipping future version {cells}")
-            continue
+        for row in table.select("tbody tr"):
+            cells = row.select("td")
+            if len(cells) <= max(date_index, versions_index):
+                logging.warning(f"Skipping row {cells}: not enough cells")
+                continue
 
-        versions = cells[versions_index].get_text().strip()
-        for version in versions.split(", "):
-            if config.first_match(version):
-                product_data.declare_version(version.strip(), date)
+            date_text = cells[date_index].get_text().strip()
+            date_text = date_text.removesuffix('.')  # Remove trailing . if present, such as for "January 20, 2026."
+            date = dates.parse_date(date_text)
+            if date > dates.today_at_midnight():
+                logging.info(f"Skipping future version {cells}")
+                continue
+
+            versions = cells[versions_index].get_text().strip()
+            for version in versions.split(", "):
+                if config.first_match(version):
+                    product_data.declare_version(version.strip(), date)

--- a/src/haproxy.py
+++ b/src/haproxy.py
@@ -1,30 +1,31 @@
 import re
 
-from common import dates, http
-from common.releasedata import ProductData, config_from_argv
+from src.common import dates, http
+from src.common.endoflife import AutoConfig, ProductFrontmatter
+from src.common.releasedata import ProductData
 
 CYCLE_PATTERN = re.compile(r"^(\d+\.\d+)/$")
 DATE_AND_VERSION_PATTERN = re.compile(r"^(\d{4})/(\d{2})/(\d{2})\s+:\s+(\d+\.\d+\.\d.?)$")  # https://regex101.com/r/1JCnFC/1
 
-config = config_from_argv()
-with ProductData(config.product) as product_data:
-    # First, get all minor releases from the download page
-    download_html = http.fetch_html(config.url)
-    minor_versions = []
-    for link in download_html.select("a"):
-        minor_version_match = CYCLE_PATTERN.match(link.attrs["href"])
-        if not minor_version_match:
-            continue
+def update(_product: ProductFrontmatter, config: AutoConfig) -> None:
+    with ProductData(config.product) as product_data:
+        # First, get all minor releases from the download page
+        download_html = http.fetch_html(config.url)
+        minor_versions = []
+        for link in download_html.select("a"):
+            minor_version_match = CYCLE_PATTERN.match(link.attrs["href"])
+            if not minor_version_match:
+                continue
 
-        minor_version = minor_version_match.groups()[0]
-        if minor_version != "1.0":  # No changelog in https://www.haproxy.org/download/1.0/src
-            minor_versions.append(minor_version)
+            minor_version = minor_version_match.groups()[0]
+            if minor_version != "1.0":  # No changelog in https://www.haproxy.org/download/1.0/src
+                minor_versions.append(minor_version)
 
-    # Then, fetches all versions from each changelog
-    changelog_urls = [f"{config.url}{minor_version}/src/CHANGELOG" for minor_version in minor_versions]
-    for changelog in http.fetch_urls(changelog_urls):
-        for line in changelog.text.split('\n'):
-            date_and_version_match = DATE_AND_VERSION_PATTERN.match(line)
-            if date_and_version_match:
-                year, month, day, version = date_and_version_match.groups()
-                product_data.declare_version(version, dates.date(int(year), int(month), int(day)))
+        # Then, fetches all versions from each changelog
+        changelog_urls = [f"{config.url}{minor_version}/src/CHANGELOG" for minor_version in minor_versions]
+        for changelog in http.fetch_urls(changelog_urls):
+            for line in changelog.text.split('\n'):
+                date_and_version_match = DATE_AND_VERSION_PATTERN.match(line)
+                if date_and_version_match:
+                    year, month, day, version = date_and_version_match.groups()
+                    product_data.declare_version(version, dates.date(int(year), int(month), int(day)))

--- a/src/ibm-aix.py
+++ b/src/ibm-aix.py
@@ -1,14 +1,17 @@
 from bs4 import BeautifulSoup
-from common import dates, http
-from common.releasedata import ProductData, config_from_argv
 
-config = config_from_argv()
-with ProductData(config.product) as product_data:
-    html = BeautifulSoup(http.fetch_javascript_url(config.url, wait_for="table"), features="html5lib")
+from src.common import dates, http
+from src.common.endoflife import AutoConfig, ProductFrontmatter
+from src.common.releasedata import ProductData
 
-    for release_table in html.find_all("table"):
-        for row in release_table.find_all("tr")[1:]:  # for all rows except the header
-            cells = row.find_all("td")
-            version = cells[0].text.strip("AIX ").replace(' TL', '.')
-            date = dates.parse_month_year_date(cells[1].text)
-            product_data.declare_version(version, date)
+
+def update(_product: ProductFrontmatter, config: AutoConfig) -> None:
+    with ProductData(config.product) as product_data:
+        html = BeautifulSoup(http.fetch_javascript_url(config.url, wait_for="table"), features="html5lib")
+
+        for release_table in html.find_all("table"):
+            for row in release_table.find_all("tr")[1:]:  # for all rows except the header
+                cells = row.find_all("td")
+                version = cells[0].text.strip("AIX ").replace(' TL', '.')
+                date = dates.parse_month_year_date(cells[1].text)
+                product_data.declare_version(version, date)

--- a/src/ibm-product-lifecycle.py
+++ b/src/ibm-product-lifecycle.py
@@ -1,7 +1,8 @@
 import logging
 
-from common import dates, http
-from common.releasedata import ProductData, config_from_argv
+from src.common import dates, http
+from src.common.endoflife import AutoConfig, ProductFrontmatter
+from src.common.releasedata import ProductData
 
 """Get release information from IBM's product lifecycle CSV file available.
 See https://www.ibm.com/support/pages/product-lifecycle-list.
@@ -10,44 +11,44 @@ See https://www.ibm.com/support/pages/product-lifecycle-list.
 def unquote(s: str) -> str:
     return s[1:-1] if s.startswith('"') and s.endswith('"') else s
 
-config = config_from_argv()
-with ProductData(config.product) as product_data:
-    product_selector = config.data["product_selector"]
-    response = http.fetch_url(config.url)
+def update(_product: ProductFrontmatter, config: AutoConfig) -> None:
+    with ProductData(config.product) as product_data:
+        product_selector = config.data["product_selector"]
+        response = http.fetch_url(config.url)
 
-    records = response.text.splitlines()
-    for record in records[1:]:  # Skip the header line
-        fields = record.split(',')
-        if len(fields) < 13:
-            logging.warning("Skipping record with insufficient fields: %s", record)
-            continue
+        records = response.text.splitlines()
+        for record in records[1:]:  # Skip the header line
+            fields = record.split(',')
+            if len(fields) < 13:
+                logging.warning("Skipping record with insufficient fields: %s", record)
+                continue
 
-        product_name = unquote(fields[1].strip())
-        if product_selector != product_name:
-            continue
+            product_name = unquote(fields[1].strip())
+            if product_selector != product_name:
+                continue
 
-        product_version = unquote(fields[2].strip())
-        match = config.first_match(product_version)
-        if not match:
-            logging.warning("Skipping '%s' version %s, no match found", product_name, product_version)
-            continue
+            product_version = unquote(fields[2].strip())
+            match = config.first_match(product_version)
+            if not match:
+                logging.warning("Skipping '%s' version %s, no match found", product_name, product_version)
+                continue
 
-        release_name = config.render(match)
-        release = product_data.get_release(release_name)
+            release_name = config.render(match)
+            release = product_data.get_release(release_name)
 
-        release_date_str = fields[6].strip()
-        if release_date_str:
-            logging.debug("Release announce for %s %s: %s", product_name, product_version, fields[7].strip())
-            release_date = dates.parse_date(release_date_str)
-            release.set_release_date(release_date)
+            release_date_str = fields[6].strip()
+            if release_date_str:
+                logging.debug("Release announce for %s %s: %s", product_name, product_version, fields[7].strip())
+                release_date = dates.parse_date(release_date_str)
+                release.set_release_date(release_date)
 
-        eol_date_str = fields[12].strip()
-        if eol_date_str:
-            logging.debug("EOL announce for %s %s: %s", product_name, product_version, fields[13].strip())
-            eol_date = dates.parse_date(eol_date_str)
-            release.set_eol(eol_date)
+            eol_date_str = fields[12].strip()
+            if eol_date_str:
+                logging.debug("EOL announce for %s %s: %s", product_name, product_version, fields[13].strip())
+                eol_date = dates.parse_date(eol_date_str)
+                release.set_eol(eol_date)
 
-        eoes_date_str = fields[14].strip()
-        if eoes_date_str:
-            eoes_date = dates.parse_date(eoes_date_str)
-            release.set_eoes(eoes_date)
+            eoes_date_str = fields[14].strip()
+            if eoes_date_str:
+                eoes_date = dates.parse_date(eoes_date_str)
+                release.set_eoes(eoes_date)

--- a/src/kuma.py
+++ b/src/kuma.py
@@ -1,7 +1,8 @@
 import logging
 
-from common import dates, http
-from common.releasedata import ProductData, config_from_argv
+from src.common import dates, http
+from src.common.endoflife import AutoConfig, ProductFrontmatter
+from src.common.releasedata import ProductData
 
 """Fetch version data for Kuma from https://raw.githubusercontent.com/kumahq/kuma/master/versions.yml.
 """
@@ -10,25 +11,25 @@ RELEASE_FIELD = 'release'
 RELEASE_DATE_FIELD = 'releaseDate'
 EOL_FIELD = 'endOfLifeDate'
 
-config = config_from_argv()
-with ProductData(config.product) as product_data:
-    versions_data = http.fetch_yaml(config.url)
+def update(_product: ProductFrontmatter, config: AutoConfig) -> None:
+    with ProductData(config.product) as product_data:
+        versions_data = http.fetch_yaml(config.url)
 
-    # Iterate through the versions and their associated dates
-    for version_info in versions_data:
-        release_name = version_info[RELEASE_FIELD]
-        if not release_name.endswith('.x'):
-            logging.info(f"skipping release with name {release_name}: does not end with '.x'")
-            continue
+        # Iterate through the versions and their associated dates
+        for version_info in versions_data:
+            release_name = version_info[RELEASE_FIELD]
+            if not release_name.endswith('.x'):
+                logging.info(f"skipping release with name {release_name}: does not end with '.x'")
+                continue
 
-        if RELEASE_DATE_FIELD not in version_info or EOL_FIELD not in version_info:
-            logging.info(f"skipping release with name {release_name}: does not contain {RELEASE_DATE_FIELD} or {EOL_FIELD} fields")
-            continue
+            if RELEASE_DATE_FIELD not in version_info or EOL_FIELD not in version_info:
+                logging.info(f"skipping release with name {release_name}: does not contain {RELEASE_DATE_FIELD} or {EOL_FIELD} fields")
+                continue
 
-        release = product_data.get_release(release_name.replace('.x', ''))
+            release = product_data.get_release(release_name.replace('.x', ''))
 
-        release_date = dates.parse_date(version_info[RELEASE_DATE_FIELD])
-        release.set_field('releaseDate', release_date)
+            release_date = dates.parse_date(version_info[RELEASE_DATE_FIELD])
+            release.set_field('releaseDate', release_date)
 
-        eol = dates.parse_date(version_info[EOL_FIELD])
-        release.set_field('eol', eol)
+            eol = dates.parse_date(version_info[EOL_FIELD])
+            release.set_field('eol', eol)

--- a/src/libreoffice.py
+++ b/src/libreoffice.py
@@ -1,7 +1,8 @@
 import logging
 
-from common import dates, http
-from common.releasedata import ProductData, config_from_argv
+from src.common import dates, http
+from src.common.endoflife import AutoConfig, ProductFrontmatter
+from src.common.releasedata import ProductData
 
 """Fetches LibreOffice versions from https://downloadarchive.documentfoundation.org/libreoffice/old/"""
 
@@ -28,31 +29,31 @@ def fetch_prereleases(url: str, text_to_match: str) -> list[str]:
     return prereleases
 
 
-config = config_from_argv()
-with ProductData(config.product) as product_data:
-    prereleases_url = config.data.get("prereleases_url", "https://www.libreoffice.org/download/download-libreoffice/")
-    prereleases_text = config.data.get("prereleases_text", "LibreOffice is available in the following prerelease versions:")
-    prerelease_prefixes = fetch_prereleases(prereleases_url, prereleases_text)
+def update(_product: ProductFrontmatter, config: AutoConfig) -> None:
+    with ProductData(config.product) as product_data:
+        prereleases_url = config.data.get("prereleases_url", "https://www.libreoffice.org/download/download-libreoffice/")
+        prereleases_text = config.data.get("prereleases_text", "LibreOffice is available in the following prerelease versions:")
+        prerelease_prefixes = fetch_prereleases(prereleases_url, prereleases_text)
 
-    html = http.fetch_html(config.url)
-    for table in html.find_all("table"):
-        for row in table.find_all("tr")[1:]:
-            cells = row.find_all("td")
-            if len(cells) < 4:
-                continue
+        html = http.fetch_html(config.url)
+        for table in html.find_all("table"):
+            for row in table.find_all("tr")[1:]:
+                cells = row.find_all("td")
+                if len(cells) < 4:
+                    continue
 
-            version_str = cells[1].get_text().strip()
-            version_match = config.first_match(version_str)
-            if not version_match:
-                logging.warning(f"Skipping version {version_str} as it does not match any known version pattern")
-                continue
-            version = config.render(version_match)
+                version_str = cells[1].get_text().strip()
+                version_match = config.first_match(version_str)
+                if not version_match:
+                    logging.warning(f"Skipping version {version_str} as it does not match any known version pattern")
+                    continue
+                version = config.render(version_match)
 
-            if any(prerelease_prefix in version for prerelease_prefix in prerelease_prefixes):
-                logging.info(f"Skipping prerelease version {version}")
-                continue
+                if any(prerelease_prefix in version for prerelease_prefix in prerelease_prefixes):
+                    logging.info(f"Skipping prerelease version {version}")
+                    continue
 
-            date_str = cells[2].get_text().strip()
-            date = dates.parse_datetime(date_str)
+                date_str = cells[2].get_text().strip()
+                date = dates.parse_datetime(date_str)
 
-            product_data.declare_version(version, date)
+                product_data.declare_version(version, date)

--- a/src/looker.py
+++ b/src/looker.py
@@ -1,32 +1,34 @@
 import re
 
 from bs4 import BeautifulSoup
-from common import dates, http
-from common.releasedata import ProductData, config_from_argv
+
+from src.common import dates, http
+from src.common.endoflife import AutoConfig, ProductFrontmatter
+from src.common.releasedata import ProductData
 
 """Fetch Looker versions from the Google Cloud release notes RSS feed.
 """
 
 ANNOUNCEMENT_PATTERN = re.compile(r"include\s+the\s+following\s+changes", re.IGNORECASE)
 
-config = config_from_argv()
-with ProductData(config.product) as product_data:
-    rss = http.fetch_xml(config.url)
+def update(_product: ProductFrontmatter, config: AutoConfig) -> None:
+    with ProductData(config.product) as product_data:
+        rss = http.fetch_xml(config.url)
 
-    for item in rss.getElementsByTagName("entry"):
-        content = item.getElementsByTagName("content")[0].firstChild.nodeValue
-        content_soup = BeautifulSoup(content, features="html5lib")
+        for item in rss.getElementsByTagName("entry"):
+            content = item.getElementsByTagName("content")[0].firstChild.nodeValue
+            content_soup = BeautifulSoup(content, features="html5lib")
 
-        announcement_match = content_soup.find(string=ANNOUNCEMENT_PATTERN)
-        if not announcement_match:
-            continue
+            announcement_match = content_soup.find(string=ANNOUNCEMENT_PATTERN)
+            if not announcement_match:
+                continue
 
-        release_match = config.first_match(announcement_match.parent.get_text())
-        if not release_match:
-            continue
-        release_name = config.render(release_match)
-        release = product_data.get_release(release_name)
+            release_match = config.first_match(announcement_match.parent.get_text())
+            if not release_match:
+                continue
+            release_name = config.render(release_match)
+            release = product_data.get_release(release_name)
 
-        date_str = item.getElementsByTagName("updated")[0].firstChild.nodeValue
-        date = dates.parse_datetime(date_str)
-        release.set_release_date(date)
+            date_str = item.getElementsByTagName("updated")[0].firstChild.nodeValue
+            date = dates.parse_datetime(date_str)
+            release.set_release_date(date)

--- a/src/lua.py
+++ b/src/lua.py
@@ -1,24 +1,25 @@
 import re
 
-from common import dates, http
-from common.releasedata import ProductData, config_from_argv
+from src.common import dates, http
+from src.common.endoflife import AutoConfig, ProductFrontmatter
+from src.common.releasedata import ProductData
 
 """Fetches Lua releases from lua.org."""
 
 RELEASED_AT_PATTERN = re.compile(r"Lua\s*(?P<release>\d+\.\d+)\s*was\s*released\s*on\s*(?P<release_date>\d+\s*\w+\s*\d{4})")
 VERSION_PATTERN = re.compile(r"(?P<version>\d+\.\d+\.\d+),\s*released\s*on\s*(?P<version_date>\d+\s*\w+\s*\d{4})")
 
-config = config_from_argv()
-with ProductData(config.product) as product_data:
-    html = http.fetch_html(config.url, features = 'html.parser')
-    page_text = html.text # HTML is broken, no way to parse it with beautifulsoup
+def update(_product: ProductFrontmatter, config: AutoConfig) -> None:
+    with ProductData(config.product) as product_data:
+        html = http.fetch_html(config.url, features = 'html.parser')
+        page_text = html.text # HTML is broken, no way to parse it with beautifulsoup
 
-    for release_match in RELEASED_AT_PATTERN.finditer(page_text):
-        release = release_match.group('release')
-        release_date = dates.parse_date(release_match.group('release_date'))
-        product_data.get_release(release).set_release_date(release_date)
+        for release_match in RELEASED_AT_PATTERN.finditer(page_text):
+            release = release_match.group('release')
+            release_date = dates.parse_date(release_match.group('release_date'))
+            product_data.get_release(release).set_release_date(release_date)
 
-    for version_match in VERSION_PATTERN.finditer(page_text):
-        version = version_match.group('version')
-        version_date = dates.parse_date(version_match.group('version_date'))
-        product_data.declare_version(version, version_date)
+        for version_match in VERSION_PATTERN.finditer(page_text):
+            version = version_match.group('version')
+            version_date = dates.parse_date(version_match.group('version_date'))
+            product_data.declare_version(version, version_date)

--- a/src/maven.py
+++ b/src/maven.py
@@ -1,24 +1,26 @@
 from datetime import datetime, timezone
 
-from common import http
-from common.releasedata import ProductData, config_from_argv
+from src.common import http
+from src.common.endoflife import AutoConfig, ProductFrontmatter
+from src.common.releasedata import ProductData
 
-config = config_from_argv()
-with ProductData(config.product) as product_data:
-    start = 0
-    group_id, artifact_id = config.url.split("/")
 
-    while True:
-        url = f"https://search.maven.org/solrsearch/select?q=g:{group_id}+AND+a:{artifact_id}&core=gav&wt=json&start={start}&rows=100"
-        data = http.fetch_json(url)
+def update(_product: ProductFrontmatter, config: AutoConfig) -> None:
+    with ProductData(config.product) as product_data:
+        start = 0
+        group_id, artifact_id = config.url.split("/")
 
-        for row in data["response"]["docs"]:
-            version_match = config.first_match(row["v"])
-            if version_match:
-                version = config.render(version_match)
-                date = datetime.fromtimestamp(row["timestamp"] / 1000, tz=timezone.utc)
-                product_data.declare_version(version, date)
+        while True:
+            url = f"https://search.maven.org/solrsearch/select?q=g:{group_id}+AND+a:{artifact_id}&core=gav&wt=json&start={start}&rows=100"
+            data = http.fetch_json(url)
 
-        start += 100
-        if data["response"]["numFound"] <= start:
-            break
+            for row in data["response"]["docs"]:
+                version_match = config.first_match(row["v"])
+                if version_match:
+                    version = config.render(version_match)
+                    date = datetime.fromtimestamp(row["timestamp"] / 1000, tz=timezone.utc)
+                    product_data.declare_version(version, date)
+
+            start += 100
+            if data["response"]["numFound"] <= start:
+                break

--- a/src/motorola-security.py
+++ b/src/motorola-security.py
@@ -2,8 +2,9 @@ import json
 import logging
 import re
 
-from common import dates, endoflife, http
-from common.releasedata import ProductData, config_from_argv
+from src.common import dates, endoflife, http
+from src.common.endoflife import AutoConfig, ProductFrontmatter
+from src.common.releasedata import ProductData
 
 
 def extract_data(url: str, key_to_search_for: str) -> dict | None:
@@ -33,27 +34,27 @@ def extract_data(url: str, key_to_search_for: str) -> dict | None:
     logging.debug(f"Found : {raw_json}")
     return json.loads(raw_json.group(0))
 
-config = config_from_argv()
-with ProductData(config.product) as product_data:
-    json_data = extract_data(config.url, "guidedAssistant")
+def update(_product: ProductFrontmatter, config: AutoConfig) -> None:
+    with ProductData(config.product) as product_data:
+        json_data = extract_data(config.url, "guidedAssistant")
 
-    for question in json_data["j"]["guidedAssistant"]["questions"]:
-        if not question.get("responses") or question["responses"][0].get("text") != "Security patch details for all Motorola products":
-            logging.debug(f"Skipping {question}")
-            continue
+        for question in json_data["j"]["guidedAssistant"]["questions"]:
+            if not question.get("responses") or question["responses"][0].get("text") != "Security patch details for all Motorola products":
+                logging.debug(f"Skipping {question}")
+                continue
 
-        lines = question["taglessText"].replace("\xa0", " ").split("\n")
-        logging.debug(lines)
+            lines = question["taglessText"].replace("\xa0", " ").split("\n")
+            logging.debug(lines)
 
-        product_id = question["agentText"]
-        label = lines[0].strip()
-        name = endoflife.to_identifier(label)
-        release = product_data.get_release(name)
-        release.set_field("link", f"https://en-us.support.motorola.com/app/software-security-update/g_id/7112/productid/{product_id}")
-        for line in lines:
-            if (m := re.search(r"^Device launched on (.*)$", line)):
-                date = dates.parse_date_or_month_year_date(m.group(1).strip()).replace(day=1)
-                release.set_release_date(date)
-            if (m := re.search(r"^Security updates will stop on (.*)$", line)):
-                eol = dates.parse_date_or_month_year_date(m.group(1).strip())
-                release.set_eol(eol)
+            product_id = question["agentText"]
+            label = lines[0].strip()
+            name = endoflife.to_identifier(label)
+            release = product_data.get_release(name)
+            release.set_field("link", f"https://en-us.support.motorola.com/app/software-security-update/g_id/7112/productid/{product_id}")
+            for line in lines:
+                if (m := re.search(r"^Device launched on (.*)$", line)):
+                    date = dates.parse_date_or_month_year_date(m.group(1).strip()).replace(day=1)
+                    release.set_release_date(date)
+                if (m := re.search(r"^Security updates will stop on (.*)$", line)):
+                    eol = dates.parse_date_or_month_year_date(m.group(1).strip())
+                    release.set_eol(eol)

--- a/src/netbsd.py
+++ b/src/netbsd.py
@@ -1,33 +1,34 @@
 import logging
 
-from common import dates, http
-from common.releasedata import ProductData, config_from_argv
+from src.common import dates, http
+from src.common.endoflife import AutoConfig, ProductFrontmatter
+from src.common.releasedata import ProductData
 
 """Fetches NetBSD versions and EOL information from https://www.netbsd.org/."""
 
-config = config_from_argv()
-with ProductData(config.product) as product_data:
-    html = http.fetch_html(config.url)
+def update(_product: ProductFrontmatter, config: AutoConfig) -> None:
+    with ProductData(config.product) as product_data:
+        html = http.fetch_html(config.url)
 
-    for row in html.select('table tbody tr'):
-        cells = [cell.get_text(strip=True) for cell in row.select('td')]
+        for row in html.select('table tbody tr'):
+            cells = [cell.get_text(strip=True) for cell in row.select('td')]
 
-        version = cells[0]
-        if not version.startswith('NetBSD'):
-            logging.info(f"Skipping row {cells}, version does not start with 'NetBSD'")
-            continue
-        version = version.split(' ')[1]
+            version = cells[0]
+            if not version.startswith('NetBSD'):
+                logging.info(f"Skipping row {cells}, version does not start with 'NetBSD'")
+                continue
+            version = version.split(' ')[1]
 
-        try:
-            release_date = dates.parse_date(cells[1])
-            product_data.declare_version(version, release_date)
-        except ValueError:
-            logging.warning(f"Skipping row {cells}, could not parse release date")
+            try:
+                release_date = dates.parse_date(cells[1])
+                product_data.declare_version(version, release_date)
+            except ValueError:
+                logging.warning(f"Skipping row {cells}, could not parse release date")
 
-        eol_str = cells[2]
-        if not eol_str or eol_str == 'Â':
-            continue
+            eol_str = cells[2]
+            if not eol_str or eol_str == 'Â':
+                continue
 
-        eol = dates.parse_date(eol_str)
-        major_version = version.split('.')[0]
-        product_data.get_release(major_version).set_eol(eol)
+            eol = dates.parse_date(eol_str)
+            major_version = version.split('.')[0]
+            product_data.get_release(major_version).set_eol(eol)

--- a/src/npm.py
+++ b/src/npm.py
@@ -1,12 +1,14 @@
-from common import dates, http
-from common.releasedata import ProductData, config_from_argv
+from src.common import dates, http
+from src.common.endoflife import AutoConfig, ProductFrontmatter
+from src.common.releasedata import ProductData
 
-config = config_from_argv()
-with ProductData(config.product) as product_data:
-    data = http.fetch_json(f"https://registry.npmjs.org/{config.url}")
-    for version_str in data["versions"]:
-        version_match = config.first_match(version_str)
-        if version_match:
-            version = config.render(version_match)
-            date = dates.parse_datetime(data["time"][version_str])
-            product_data.declare_version(version, date)
+
+def update(_product: ProductFrontmatter, config: AutoConfig) -> None:
+    with ProductData(config.product) as product_data:
+        data = http.fetch_json(f"https://registry.npmjs.org/{config.url}")
+        for version_str in data["versions"]:
+            version_match = config.first_match(version_str)
+            if version_match:
+                version = config.render(version_match)
+                date = dates.parse_datetime(data["time"][version_str])
+                product_data.declare_version(version, date)

--- a/src/nutanix.py
+++ b/src/nutanix.py
@@ -1,16 +1,15 @@
-from common import dates, http
-from common.releasedata import ProductData, config_from_argv
+from src.common import dates, http
+from src.common.endoflife import AutoConfig, ProductFrontmatter
+from src.common.releasedata import ProductData
 
 """Fetch Nutanix products versions from https://portal.nutanix.com/api/v1."""
 
-config = config_from_argv()
-with ProductData(config.product) as product_data:
-    data = http.fetch_json(f"https://portal.nutanix.com/api/v1/eol/find?type={config.url}")
+def update(_product: ProductFrontmatter, config: AutoConfig) -> None:
+    with ProductData(config.product) as product_data:
+        data = http.fetch_json(f"https://portal.nutanix.com/api/v1/eol/find?type={config.url}")
 
-    for version_data in data["contents"]:
-        release_name = '.'.join(version_data["version"].split(".")[:2])
-
-        if 'GENERAL_AVAILABILITY' in version_data:
-            version = version_data["version"]
-            date = dates.parse_datetime(version_data["GENERAL_AVAILABILITY"]).replace(second=0)
-            product_data.declare_version(version, date)
+        for version_data in data["contents"]:
+            if 'GENERAL_AVAILABILITY' in version_data:
+                version = version_data["version"]
+                date = dates.parse_datetime(version_data["GENERAL_AVAILABILITY"]).replace(second=0)
+                product_data.declare_version(version, date)

--- a/src/nvidia-releases.py
+++ b/src/nvidia-releases.py
@@ -2,44 +2,45 @@ import logging
 import re
 from urllib.parse import urlparse
 
-from common import http
-from common.releasedata import ProductData, config_from_argv
+from src.common import http
+from src.common.endoflife import AutoConfig, ProductFrontmatter
+from src.common.releasedata import ProductData
 
 WINDOWS_VERSION_REGEX = re.compile(r'Version .+\(Linux\)/(?P<version>.+)\(Windows\)')
 
-config = config_from_argv()
-with ProductData(config.product) as product_data:
-    data = http.fetch_json(config.url)
-    for release_name in data:
-        release_data = data[release_name]
-        latest_version_data = release_data.get('driver_info')[0]
-        latest = latest_version_data['release_version']
-        latest_release_data = latest_version_data['release_date']
-        link = latest_version_data['release_notes']
+def update(_product: ProductFrontmatter, config: AutoConfig) -> None:
+    with ProductData(config.product) as product_data:
+        data = http.fetch_json(config.url)
+        for release_name in data:
+            release_data = data[release_name]
+            latest_version_data = release_data.get('driver_info')[0]
+            latest = latest_version_data['release_version']
+            latest_release_data = latest_version_data['release_date']
+            link = latest_version_data['release_notes']
 
-        # Only linux releases are documented in the JSON document.
-        release = product_data.get_release(f"r{release_name}-linux")
-        release.set_field('latest', latest)
-        release.set_field('latestReleaseDate', latest_release_data)
-        release.set_field('link', link)
+            # Only linux releases are documented in the JSON document.
+            release = product_data.get_release(f"r{release_name}-linux")
+            release.set_field('latest', latest)
+            release.set_field('latestReleaseDate', latest_release_data)
+            release.set_field('link', link)
 
-        # Windows releases are documented in the release notes.
-        if urlparse(link).hostname != 'docs.nvidia.com':
-            logging.debug("Skipping windows release %s, link %s is not from docs.nvidia.com", release_name, link)
-            continue
+            # Windows releases are documented in the release notes.
+            if urlparse(link).hostname != 'docs.nvidia.com':
+                logging.debug("Skipping windows release %s, link %s is not from docs.nvidia.com", release_name, link)
+                continue
 
-        release_note_html = http.fetch_html(link)
-        release_note_title = release_note_html.select_one('h2.title.topictitle1')
-        if not release_note_title:
-            logging.warning("Skipping windows release %s, could not find release note title in '%s'", release_name, link)
-            continue
+            release_note_html = http.fetch_html(link)
+            release_note_title = release_note_html.select_one('h2.title.topictitle1')
+            if not release_note_title:
+                logging.warning("Skipping windows release %s, could not find release note title in '%s'", release_name, link)
+                continue
 
-        windows_version_match = WINDOWS_VERSION_REGEX.search(release_note_title.text)
-        if not windows_version_match:
-            logging.warning("Skipping windows release %s, could not find version in release note title '%s'", release_name, release_note_title.text)
-            continue
+            windows_version_match = WINDOWS_VERSION_REGEX.search(release_note_title.text)
+            if not windows_version_match:
+                logging.warning("Skipping windows release %s, could not find version in release note title '%s'", release_name, release_note_title.text)
+                continue
 
-        release = product_data.get_release(f"r{release_name}-windows")
-        release.set_field('latest', windows_version_match.group('version'))
-        release.set_field('latestReleaseDate', latest_release_data)
-        release.set_field('link', link)
+            release = product_data.get_release(f"r{release_name}-windows")
+            release.set_field('latest', windows_version_match.group('version'))
+            release.set_field('latestReleaseDate', latest_release_data)
+            release.set_field('link', link)

--- a/src/oracle-jdk.py
+++ b/src/oracle-jdk.py
@@ -1,23 +1,24 @@
-from common import dates, http
-from common.http import FIREFOX_USER_AGENT
-from common.releasedata import ProductData, config_from_argv
+from src.common import dates, http
+from src.common.endoflife import AutoConfig, ProductFrontmatter
+from src.common.http import FIREFOX_USER_AGENT
+from src.common.releasedata import ProductData
 
 """Fetch Java versions from https://www.java.com/releases/.
 
 This script is using requests-html because the page needs JavaScript to render correctly."""
 
-config = config_from_argv()
-with ProductData(config.product) as product_data:
-    soup = http.fetch_html(config.url, user_agent=FIREFOX_USER_AGENT)
+def update(_product: ProductFrontmatter, config: AutoConfig) -> None:
+    with ProductData(config.product) as product_data:
+        soup = http.fetch_html(config.url, user_agent=FIREFOX_USER_AGENT)
 
-    previous_date = None
-    for row in soup.select('#released tr'):
-        version_cell = row.select_one('td.anchor')
-        if version_cell:
-            version = version_cell.attrs['id']
-            date_str = row.select('td, th')[1].text
-            date = dates.parse_date(date_str) if date_str else previous_date
-            product_data.declare_version(version, date)
-            previous_date = date
+        previous_date = None
+        for row in soup.select('#released tr'):
+            version_cell = row.select_one('td.anchor')
+            if version_cell:
+                version = version_cell.attrs['id']
+                date_str = row.select('td, th')[1].text
+                date = dates.parse_date(date_str) if date_str else previous_date
+                product_data.declare_version(version, date)
+                previous_date = date
 
-    product_data.remove_version('1.0_alpha')  # the only version we don't want, a regex is not needed
+        product_data.remove_version('1.0_alpha')  # the only version we don't want, a regex is not needed

--- a/src/pan-os.py
+++ b/src/pan-os.py
@@ -1,13 +1,14 @@
-from common import dates, http
-from common.releasedata import ProductData, config_from_argv
+from src.common import dates, http
+from src.common.endoflife import AutoConfig, ProductFrontmatter
+from src.common.releasedata import ProductData
 
 """Fetches pan-os versions from https://github.com/mrjcap/panos-versions/."""
 
-config = config_from_argv()
-with ProductData(config.product) as product_data:
-    versions = http.fetch_json(config.url)
+def update(_product: ProductFrontmatter, config: AutoConfig) -> None:
+    with ProductData(config.product) as product_data:
+        versions = http.fetch_json(config.url)
 
-    for version in versions:
-        name = version['version']
-        date = dates.parse_datetime(version['released-on'])
-        product_data.declare_version(name, date)
+        for version in versions:
+            name = version['version']
+            date = dates.parse_datetime(version['released-on'])
+            product_data.declare_version(name, date)

--- a/src/php.py
+++ b/src/php.py
@@ -1,16 +1,18 @@
-from common import dates, http
-from common.releasedata import ProductData, config_from_argv
+from src.common import dates, http
+from src.common.endoflife import AutoConfig, ProductFrontmatter
+from src.common.releasedata import ProductData
 
-config = config_from_argv()
-with ProductData(config.product) as product_data:
-    # Fetch major versions
-    latest_by_major = http.fetch_url(config.url).json()
-    major_version_urls = [f"{config.url}&version={major_version}" for major_version in latest_by_major]
 
-    # Fetch all versions for major versions
-    for major_versions_response in http.fetch_urls(major_version_urls):
-        major_versions_data = major_versions_response.json()
-        for version in major_versions_data:
-            if config.first_match(version):  # exclude versions such as "3.0.x (latest)"
-                date = dates.parse_date(major_versions_data[version]["date"])
-                product_data.declare_version(version, date)
+def update(_product: ProductFrontmatter, config: AutoConfig) -> None:
+    with ProductData(config.product) as product_data:
+        # Fetch major versions
+        latest_by_major = http.fetch_url(config.url).json()
+        major_version_urls = [f"{config.url}&version={major_version}" for major_version in latest_by_major]
+
+        # Fetch all versions for major versions
+        for major_versions_response in http.fetch_urls(major_version_urls):
+            major_versions_data = major_versions_response.json()
+            for version in major_versions_data:
+                if config.first_match(version):  # exclude versions such as "3.0.x (latest)"
+                    date = dates.parse_date(major_versions_data[version]["date"])
+                    product_data.declare_version(version, date)

--- a/src/plesk.py
+++ b/src/plesk.py
@@ -1,23 +1,24 @@
-from common import dates, http
-from common.releasedata import ProductData, config_from_argv
+from src.common import dates, http
+from src.common.endoflife import AutoConfig, ProductFrontmatter
+from src.common.releasedata import ProductData
 
 """Fetches versions from Plesk's change log.
 
 Only 18.0.20.3 and later will be picked up, as the format of the change log for 18.0.20 and 18.0.19 are different and
 there is no entry for GA of version 18.0.18 and older."""
 
-config = config_from_argv()
-with ProductData(config.product) as product_data:
-    html = http.fetch_html(config.url)
+def update(_product: ProductFrontmatter, config: AutoConfig) -> None:
+    with ProductData(config.product) as product_data:
+        html = http.fetch_html(config.url)
 
-    for release in html.find_all("div", class_="changelog-entry--obsidian"):
-        version = release.h2.text.strip()
-        if not version.startswith('Plesk Obsidian 18'):
-            continue
+        for release in html.find_all("div", class_="changelog-entry--obsidian"):
+            version = release.h2.text.strip()
+            if not version.startswith('Plesk Obsidian 18'):
+                continue
 
-        version = version.replace(' Update ', '.').replace('Plesk Obsidian ', '')
-        if ' ' in version:
-            continue
+            version = version.replace(' Update ', '.').replace('Plesk Obsidian ', '')
+            if ' ' in version:
+                continue
 
-        date = dates.parse_date(release.p.text)
-        product_data.declare_version(version, date)
+            date = dates.parse_date(release.p.text)
+            product_data.declare_version(version, date)

--- a/src/pypi.py
+++ b/src/pypi.py
@@ -1,15 +1,17 @@
-from common import dates, http
-from common.releasedata import ProductData, config_from_argv
+from src.common import dates, http
+from src.common.endoflife import AutoConfig, ProductFrontmatter
+from src.common.releasedata import ProductData
 
-config = config_from_argv()
-with ProductData(config.product) as product_data:
-    data = http.fetch_json(f"https://pypi.org/pypi/{config.url}/json")
 
-    for version_str in data["releases"]:
-        version_match = config.first_match(version_str)
-        version_data = data["releases"][version_str]
+def update(_product: ProductFrontmatter, config: AutoConfig) -> None:
+    with ProductData(config.product) as product_data:
+        data = http.fetch_json(f"https://pypi.org/pypi/{config.url}/json")
 
-        if version_match and version_data and not version_data[0]['yanked']:
-            version = config.render(version_match)
-            date = dates.parse_datetime(version_data[0]["upload_time_iso_8601"])
-            product_data.declare_version(version, date)
+        for version_str in data["releases"]:
+            version_match = config.first_match(version_str)
+            version_data = data["releases"][version_str]
+
+            if version_match and version_data and not version_data[0]['yanked']:
+                version = config.render(version_match)
+                date = dates.parse_datetime(version_data[0]["upload_time_iso_8601"])
+                product_data.declare_version(version, date)

--- a/src/rds.py
+++ b/src/rds.py
@@ -1,7 +1,8 @@
 import logging
 
-from common import dates, http
-from common.releasedata import ProductData, config_from_argv
+from src.common import dates, http
+from src.common.endoflife import AutoConfig, ProductFrontmatter
+from src.common.releasedata import ProductData
 
 """Fetches Amazon RDS versions from the version management pages on AWS docs.
 
@@ -9,22 +10,22 @@ Pages parsed by this script are expected to have version tables with a version i
 in the third column (usually named 'RDS release date').
 """
 
-config = config_from_argv()
-with ProductData(config.product) as product_data:
-    html = http.fetch_html(config.url)
+def update(_product: ProductFrontmatter, config: AutoConfig) -> None:
+    with ProductData(config.product) as product_data:
+        html = http.fetch_html(config.url)
 
-    for table in html.find_all("table"):
-        for row in table.find_all("tr"):
-            columns = row.find_all("td")
-            if len(columns) <= 3:
-                continue
+        for table in html.find_all("table"):
+            for row in table.find_all("tr"):
+                columns = row.find_all("td")
+                if len(columns) <= 3:
+                    continue
 
-            version_text = columns[0].text.strip()
-            version_match = config.first_match(version_text)
-            if not version_match:
-                logging.warning(f"Skipping {version_text}: does not match any version pattern")
-                continue
+                version_text = columns[0].text.strip()
+                version_match = config.first_match(version_text)
+                if not version_match:
+                    logging.warning(f"Skipping {version_text}: does not match any version pattern")
+                    continue
 
-            version = config.render(version_match)
-            date = dates.parse_date(columns[2].text)
-            product_data.declare_version(version, date)
+                version = config.render(version_match)
+                date = dates.parse_date(columns[2].text)
+                product_data.declare_version(version, date)

--- a/src/red-hat-jboss-eap-7.py
+++ b/src/red-hat-jboss-eap-7.py
@@ -1,44 +1,45 @@
 import logging
 
-from common import dates, http
-from common.releasedata import ProductData, config_from_argv
+from src.common import dates, http
+from src.common.endoflife import AutoConfig, ProductFrontmatter
+from src.common.releasedata import ProductData
 
 """Fetches RedHat JBoss EAP version data for JBoss 7"""
 
-config = config_from_argv()
-with ProductData(config.product) as product_data:
-    html = http.fetch_html(config.url)
+def update(_product: ProductFrontmatter, config: AutoConfig) -> None:
+    with ProductData(config.product) as product_data:
+        html = http.fetch_html(config.url)
 
-    for h4 in html.find_all("h4"):
-        title = h4.get_text(strip=True)
-        if not title.startswith("7."):
-            continue
-
-        release = title[:3]
-        version_table = h4.find_next("table")
-        if not version_table:
-            logging.warning(f"Version table not found for {title}")
-            continue
-
-        for (i, row) in enumerate(version_table.find_all("tr")):
-            if i == 0:  # Skip the first row (header)
+        for h4 in html.find_all("h4"):
+            title = h4.get_text(strip=True)
+            if not title.startswith("7."):
                 continue
 
-            columns = row.find_all("td")
-            # Get the version name without the content of the <sup> tag, if present
-            name_str = ''.join([content for content in columns[0].contents if isinstance(content, str)]).strip()
-            name = name_str.replace("GA", "Update 0").replace("Update ", release + ".")
-            if not config.first_match(name):
+            release = title[:3]
+            version_table = h4.find_next("table")
+            if not version_table:
+                logging.warning(f"Version table not found for {title}")
                 continue
 
-            date_str = columns[1].text.strip()
-            if date_str == "TBD" or date_str == "TDB": # Placeholder for a future release
-                continue
+            for (i, row) in enumerate(version_table.find_all("tr")):
+                if i == 0:  # Skip the first row (header)
+                    continue
 
-            if date_str == "[July 21, 2021][d7400]":
-                # Temporary fix for a typo in the source page
-                date_str = "July 21 2021"
+                columns = row.find_all("td")
+                # Get the version name without the content of the <sup> tag, if present
+                name_str = ''.join([content for content in columns[0].contents if isinstance(content, str)]).strip()
+                name = name_str.replace("GA", "Update 0").replace("Update ", release + ".")
+                if not config.first_match(name):
+                    continue
+
+                date_str = columns[1].text.strip()
+                if date_str == "TBD" or date_str == "TDB": # Placeholder for a future release
+                    continue
+
+                if date_str == "[July 21, 2021][d7400]":
+                    # Temporary fix for a typo in the source page
+                    date_str = "July 21 2021"
 
 
-            date = dates.parse_date(date_str)
-            product_data.declare_version(name, date)
+                date = dates.parse_date(date_str)
+                product_data.declare_version(name, date)

--- a/src/red-hat-jboss-eap-8.py
+++ b/src/red-hat-jboss-eap-8.py
@@ -1,20 +1,21 @@
 import re
 
-from common import dates, http
-from common.releasedata import ProductData, config_from_argv
+from src.common import dates, http
+from src.common.endoflife import AutoConfig, ProductFrontmatter
+from src.common.releasedata import ProductData
 
 """Fetches the latest RedHat JBoss EAP version data for JBoss 8.0"""
 
-config = config_from_argv()
-with ProductData(config.product) as product_data:
-    xml = http.fetch_xml(config.url)
+def update(_product: ProductFrontmatter, config: AutoConfig) -> None:
+    with ProductData(config.product) as product_data:
+        xml = http.fetch_xml(config.url)
 
-    versioning = xml.getElementsByTagName("metadata")[0].getElementsByTagName("versioning")[0]
+        versioning = xml.getElementsByTagName("metadata")[0].getElementsByTagName("versioning")[0]
 
-    latest_str = versioning.getElementsByTagName("latest")[0].firstChild.nodeValue
-    latest_name = "8.0." + re.match(r"^..(.*)\.GA", latest_str).group(1)
+        latest_str = versioning.getElementsByTagName("latest")[0].firstChild.nodeValue
+        latest_name = "8.0." + re.match(r"^..(.*)\.GA", latest_str).group(1)
 
-    latest_date_str = versioning.getElementsByTagName("lastUpdated")[0].firstChild.nodeValue
-    latest_date = dates.parse_datetime(latest_date_str)
+        latest_date_str = versioning.getElementsByTagName("lastUpdated")[0].firstChild.nodeValue
+        latest_date = dates.parse_datetime(latest_date_str)
 
-    product_data.declare_version(latest_name, latest_date)
+        product_data.declare_version(latest_name, latest_date)

--- a/src/red-hat-openshift.py
+++ b/src/red-hat-openshift.py
@@ -1,9 +1,10 @@
 import re
 from pathlib import Path
 
-from common import dates
-from common.git import Git
-from common.releasedata import ProductData, config_from_argv
+from src.common import dates
+from src.common.endoflife import AutoConfig, ProductFrontmatter
+from src.common.git import Git
+from src.common.releasedata import ProductData
 
 """Fetches Red Hat OpenShift versions from the documentation's git repository"""
 
@@ -34,38 +35,38 @@ def _declare_versions_from_content(product_data: ProductData, content: str, bran
             dates.parse_date(date_str),
         )
 
-config = config_from_argv()
-with ProductData(config.product) as product_data:
-    git = Git(config.url)
-    git.setup()
+def update(_product: ProductFrontmatter, config: AutoConfig) -> None:
+    with ProductData(config.product) as product_data:
+        git = Git(config.url)
+        git.setup()
 
-    # only fetch v4+ branches, because the format was different in openshift v3
-    for branch in git.list_branches("refs/heads/enterprise-[4-9]*"):
-        if "-archive-" in branch:
-            continue
+        # only fetch v4+ branches, because the format was different in openshift v3
+        for branch in git.list_branches("refs/heads/enterprise-[4-9]*"):
+            if "-archive-" in branch:
+                continue
 
-        branch_version = branch.split("-")[1]
-        file_version = branch_version.replace(".", "-")
-        release_notes_filename = f"release_notes/ocp-{file_version}-release-notes.adoc"
-        git.checkout(branch, file_list=[release_notes_filename])
+            branch_version = branch.split("-")[1]
+            file_version = branch_version.replace(".", "-")
+            release_notes_filename = f"release_notes/ocp-{file_version}-release-notes.adoc"
+            git.checkout(branch, file_list=[release_notes_filename])
 
-        release_notes_file = git.repo_dir / release_notes_filename
-        if not release_notes_file.exists():
-            continue
+            release_notes_file = git.repo_dir / release_notes_filename
+            if not release_notes_file.exists():
+                continue
 
-        content = _read_text(release_notes_file)
+            content = _read_text(release_notes_file)
 
-        # Older releases are declared inline in the main release notes file, while
-        # newer z-stream entries are pulled in from separate module files. A single
-        # branch can contain both, so both need to be parsed.
-        _declare_versions_from_content(product_data, content, branch_version)
+            # Older releases are declared inline in the main release notes file, while
+            # newer z-stream entries are pulled in from separate module files. A single
+            # branch can contain both, so both need to be parsed.
+            _declare_versions_from_content(product_data, content, branch_version)
 
-        module_files = MODULE_INCLUDE_PATTERN.findall(content)
-        if module_files:
-            git.checkout(branch, file_list=[release_notes_filename, *module_files])
-            for module_file in module_files:
-                module_path = git.repo_dir / module_file
-                if not module_path.exists():
-                    continue
+            module_files = MODULE_INCLUDE_PATTERN.findall(content)
+            if module_files:
+                git.checkout(branch, file_list=[release_notes_filename, *module_files])
+                for module_file in module_files:
+                    module_path = git.repo_dir / module_file
+                    if not module_path.exists():
+                        continue
 
-                _declare_versions_from_content(product_data, _read_text(module_path), branch_version)
+                    _declare_versions_from_content(product_data, _read_text(module_path), branch_version)

--- a/src/red-hat-satellite.py
+++ b/src/red-hat-satellite.py
@@ -1,29 +1,30 @@
 import logging
 
-from common import dates, http
-from common.releasedata import ProductData, config_from_argv
+from src.common import dates, http
+from src.common.endoflife import AutoConfig, ProductFrontmatter
+from src.common.releasedata import ProductData
 
 """Fetches Satellite versions from access.redhat.com.
 
 A few of the older versions, such as 'Satellite 6.1 GA Release (Build 6.1.1)', were ignored because too hard to parse."""
 
-config = config_from_argv()
-with ProductData(config.product) as product_data:
-    html = http.fetch_html(config.url)
+def update(_product: ProductFrontmatter, config: AutoConfig) -> None:
+    with ProductData(config.product) as product_data:
+        html = http.fetch_html(config.url)
 
-    for table in html.findAll("tbody"):
-        for tr in table.findAll("tr"):
-            td_list = tr.findAll("td")
+        for table in html.findAll("tbody"):
+            for tr in table.findAll("tr"):
+                td_list = tr.findAll("td")
 
-            version_str = td_list[0].get_text().replace(' GA', '.0').strip()  # x.y GA => x.y.0
-            version_match = config.first_match(version_str)
-            if not version_match:
-                logging.warning(f"Skipping version '{version_str}': does not match any version pattern.")
-                continue
-            version = version_match["version"].replace('-', '.')  # a.b.c-d => a.b.c.d
+                version_str = td_list[0].get_text().replace(' GA', '.0').strip()  # x.y GA => x.y.0
+                version_match = config.first_match(version_str)
+                if not version_match:
+                    logging.warning(f"Skipping version '{version_str}': does not match any version pattern.")
+                    continue
+                version = version_match["version"].replace('-', '.')  # a.b.c-d => a.b.c.d
 
-            date_str = td_list[1].get_text().strip()
-            date_str = '2024-12-04' if date_str == '2024-12-041' else date_str  # there is a typo for 6.15.5
-            date = dates.parse_date(date_str)
+                date_str = td_list[1].get_text().strip()
+                date_str = '2024-12-04' if date_str == '2024-12-041' else date_str  # there is a typo for 6.15.5
+                date = dates.parse_date(date_str)
 
-            product_data.declare_version(version, date)
+                product_data.declare_version(version, date)

--- a/src/redhat_lifecycles.py
+++ b/src/redhat_lifecycles.py
@@ -1,8 +1,9 @@
 import logging
 import urllib.parse
 
-from common import dates, http
-from common.releasedata import ProductData, config_from_argv
+from src.common import dates, http
+from src.common.endoflife import AutoConfig, ProductFrontmatter
+from src.common.releasedata import ProductData
 
 """Fetches EOL dates from the Red Hat Product Life Cycle Data API.
 
@@ -18,26 +19,26 @@ class Mapping:
     def get_field_for(self, phase_name: str) -> str | None:
         return self.fields_by_phase.get(phase_name.lower(), None)
 
-config = config_from_argv()
-with ProductData(config.product) as product_data:
-    name = urllib.parse.quote(config.url)
-    mapping = Mapping(config.data["fields"])
+def update(_product: ProductFrontmatter, config: AutoConfig) -> None:
+    with ProductData(config.product) as product_data:
+        name = urllib.parse.quote(config.url)
+        mapping = Mapping(config.data["fields"])
 
-    data = http.fetch_json('https://access.redhat.com/product-life-cycles/api/v1/products?name=' + name)
+        data = http.fetch_json('https://access.redhat.com/product-life-cycles/api/v1/products?name=' + name)
 
-    for version in data["data"][0]["versions"]:
-        version_name = version["name"]
-        version_match = config.first_match(version_name)
-        if not version_match:
-            logging.warning(f"Ignoring version '{version_name}', config is {config}")
-            continue
-
-        release = product_data.get_release(config.render(version_match))
-        for phase in version["phases"]:
-            field = mapping.get_field_for(phase["name"])
-            if not field:
-                logging.debug(f"Ignoring phase '{phase['name']}': not mapped")
+        for version in data["data"][0]["versions"]:
+            version_name = version["name"]
+            version_match = config.first_match(version_name)
+            if not version_match:
+                logging.warning(f"Ignoring version '{version_name}', config is {config}")
                 continue
 
-            date = dates.parse_datetime(phase["date"])
-            release.set_field(field, date)
+            release = product_data.get_release(config.render(version_match))
+            for phase in version["phases"]:
+                field = mapping.get_field_for(phase["name"])
+                if not field:
+                    logging.debug(f"Ignoring phase '{phase['name']}': not mapped")
+                    continue
+
+                date = dates.parse_datetime(phase["date"])
+                release.set_field(field, date)

--- a/src/release_table.py
+++ b/src/release_table.py
@@ -4,9 +4,11 @@ from datetime import datetime
 from re import Match
 
 from bs4 import BeautifulSoup
-from common import dates, endoflife, http
-from common.releasedata import ProductData, config_from_argv
 from liquid import Template
+
+from src.common import dates, endoflife, http
+from src.common.endoflife import AutoConfig, ProductFrontmatter
+from src.common.releasedata import ProductData
 
 """Fetch release-level data from an HTML table in a web page.
 
@@ -159,73 +161,73 @@ class Field:
         return f"{self.name}({self.column})"
 
 
-config = config_from_argv()
-with ProductData(config.product) as product_data:
-    user_agent: str = config.data.get("user_agent", http.ENDOFLIFE_BOT_USER_AGENT)
+def update(_product: ProductFrontmatter, config: AutoConfig) -> None:
+    with ProductData(config.product) as product_data:
+        user_agent: str = config.data.get("user_agent", http.ENDOFLIFE_BOT_USER_AGENT)
 
-    render_js: bool = config.data.get("render_javascript", False)
-    render_js_wait_until: str | None = config.data.get("render_javascript_wait_until", None)
-    render_js_wait_for: str | None = config.data.get("render_javascript_wait_for", None)
-    render_js_click_selector: str | None = config.data.get("render_javascript_click_selector", None)
-    render_js_headless: str | None = config.data.get("render_javascript_headless", None)
+        render_js: bool = config.data.get("render_javascript", False)
+        render_js_wait_until: str | None = config.data.get("render_javascript_wait_until", None)
+        render_js_wait_for: str | None = config.data.get("render_javascript_wait_for", None)
+        render_js_click_selector: str | None = config.data.get("render_javascript_click_selector", None)
+        render_js_headless: str | None = config.data.get("render_javascript_headless", None)
 
-    table_selector: str = config.data.get("selector", "table")
-    header_row_selector: str = config.data.get("header_selector", "thead tr")
-    rows_selector: str = config.data.get("rows_selector", "tbody tr")
-    cells_selector: str = "td, th"
+        table_selector: str = config.data.get("selector", "table")
+        header_row_selector: str = config.data.get("header_selector", "thead tr")
+        rows_selector: str = config.data.get("rows_selector", "tbody tr")
+        cells_selector: str = "td, th"
 
-    remove_if_undefined_field: str | None = config.data.get("remove_if_undefined", None)
+        remove_if_undefined_field: str | None = config.data.get("remove_if_undefined", None)
 
-    release_cycle_field = Field("releaseCycle", config.data["fields"].pop("releaseCycle"))
-    fields = [Field(name, definition) for name, definition in config.data["fields"].items()]
+        release_cycle_field = Field("releaseCycle", config.data["fields"].pop("releaseCycle"))
+        fields = [Field(name, definition) for name, definition in config.data["fields"].items()]
 
-    if render_js:
-        response_text = http.fetch_javascript_url(config.url, user_agent=user_agent, headless=render_js_headless,
-                                                  wait_until=render_js_wait_until, wait_for=render_js_wait_for,
-                                                  click_selector=render_js_click_selector)
-    else:
-        response_text = http.fetch_url(config.url, user_agent=user_agent).text
-    soup = BeautifulSoup(response_text, features="html5lib")
+        if render_js:
+            response_text = http.fetch_javascript_url(config.url, user_agent=user_agent, headless=render_js_headless,
+                                                      wait_until=render_js_wait_until, wait_for=render_js_wait_for,
+                                                      click_selector=render_js_click_selector)
+        else:
+            response_text = http.fetch_url(config.url, user_agent=user_agent).text
+        soup = BeautifulSoup(response_text, features="html5lib")
 
-    for table in soup.select(table_selector):
-        header_row = table.select_one(header_row_selector)
-        if not header_row:
-            logging.info(f"skipping table with attributes {table.attrs}: no header row found")
-            continue
+        for table in soup.select(table_selector):
+            header_row = table.select_one(header_row_selector)
+            if not header_row:
+                logging.info(f"skipping table with attributes {table.attrs}: no header row found")
+                continue
 
-        headers = [normalize_header(th.get_text()) for th in header_row.select(cells_selector)]
-        logging.info(f"processing table with headers {headers}")
+            headers = [normalize_header(th.get_text()) for th in header_row.select(cells_selector)]
+            logging.info(f"processing table with headers {headers}")
 
-        try:
-            fields_index = {"releaseCycle": headers.index(release_cycle_field.column)}
-            for field in fields:
-                fields_index[field.name] = field.column if field.is_index else headers.index(field.column)
-            min_column_count = max(fields_index.values()) + 1
-
-            for row in table.select(rows_selector):
-                cells = [cell.get_text().strip() for cell in row.select(cells_selector)]
-                if len(cells) < min_column_count:
-                    logging.debug(f"skipping row {cells}: not enough columns")
-                    continue
-
-                raw_release_name = cells[fields_index[release_cycle_field.name]]
-                release_name = release_cycle_field.extract_from(raw_release_name)
-                if not release_name:
-                    logging.debug(f"skipping row {cells}: invalid release cycle '{raw_release_name}', "
-                                 f"should match one of {release_cycle_field.include_version_patterns} "
-                                 f"and not match all of {release_cycle_field.exclude_version_patterns}")
-                    continue
-
-                release = product_data.get_release(release_name)
+            try:
+                fields_index = {"releaseCycle": headers.index(release_cycle_field.column)}
                 for field in fields:
-                    raw_field = cells[fields_index[field.name]]
-                    try:
-                        release.set_field(field.name, field.extract_from(raw_field))
-                    except ValueError as e:
-                        logging.debug(f"skipping cell {raw_field} for {release}: {e}")
+                    fields_index[field.name] = field.column if field.is_index else headers.index(field.column)
+                min_column_count = max(fields_index.values()) + 1
 
-                if remove_if_undefined_field and not release.get_field(remove_if_undefined_field):
-                    product_data.remove_release(release_name, f"{remove_if_undefined_field} is not defined")
+                for row in table.select(rows_selector):
+                    cells = [cell.get_text().strip() for cell in row.select(cells_selector)]
+                    if len(cells) < min_column_count:
+                        logging.debug(f"skipping row {cells}: not enough columns")
+                        continue
 
-        except ValueError as e:
-            logging.info(f"skipping table with headers {headers}: {e}")
+                    raw_release_name = cells[fields_index[release_cycle_field.name]]
+                    release_name = release_cycle_field.extract_from(raw_release_name)
+                    if not release_name:
+                        logging.debug(f"skipping row {cells}: invalid release cycle '{raw_release_name}', "
+                                     f"should match one of {release_cycle_field.include_version_patterns} "
+                                     f"and not match all of {release_cycle_field.exclude_version_patterns}")
+                        continue
+
+                    release = product_data.get_release(release_name)
+                    for field in fields:
+                        raw_field = cells[fields_index[field.name]]
+                        try:
+                            release.set_field(field.name, field.extract_from(raw_field))
+                        except ValueError as e:
+                            logging.debug(f"skipping cell {raw_field} for {release}: {e}")
+
+                    if remove_if_undefined_field and not release.get_field(remove_if_undefined_field):
+                        product_data.remove_release(release_name, f"{remove_if_undefined_field} is not defined")
+
+            except ValueError as e:
+                logging.info(f"skipping table with headers {headers}: {e}")

--- a/src/rhel.py
+++ b/src/rhel.py
@@ -1,24 +1,25 @@
 import re
 
-from common import dates, http
-from common.releasedata import ProductData, config_from_argv
+from src.common import dates, http
+from src.common.endoflife import AutoConfig, ProductFrontmatter
+from src.common.releasedata import ProductData
 
 # https://regex101.com/r/877ibq/1
 VERSION_PATTERN = re.compile(r"RHEL (?P<major>\d)(\. ?(?P<minor>\d+))?(( Update (?P<minor2>\d))| GA)?")
 
-config = config_from_argv()
-with ProductData(config.product) as product_data:
-    html = http.fetch_html(config.url)
+def update(_product: ProductFrontmatter, config: AutoConfig) -> None:
+    with ProductData(config.product) as product_data:
+        html = http.fetch_html(config.url)
 
-    for tr in html.findAll("tr"):
-        td_list = tr.findAll("td")
-        if len(td_list) == 0:
-            continue
+        for tr in html.findAll("tr"):
+            td_list = tr.findAll("td")
+            if len(td_list) == 0:
+                continue
 
-        version_str = td_list[0].get_text().strip()
-        version_match = VERSION_PATTERN.match(version_str).groupdict()
-        version = version_match["major"]
-        version += ("." + version_match["minor"]) if version_match["minor"] else ""
-        version += ("." + version_match["minor2"]) if version_match["minor2"] else ""
-        date = dates.parse_date(td_list[1].get_text())
-        product_data.declare_version(version, date)
+            version_str = td_list[0].get_text().strip()
+            version_match = VERSION_PATTERN.match(version_str).groupdict()
+            version = version_match["major"]
+            version += ("." + version_match["minor"]) if version_match["minor"] else ""
+            version += ("." + version_match["minor2"]) if version_match["minor2"] else ""
+            date = dates.parse_date(td_list[1].get_text())
+            product_data.declare_version(version, date)

--- a/src/rocky-linux.py
+++ b/src/rocky-linux.py
@@ -1,17 +1,19 @@
 import logging
 
-from common import dates, http
-from common.releasedata import ProductData, config_from_argv
+from src.common import dates, http
+from src.common.endoflife import AutoConfig, ProductFrontmatter
+from src.common.releasedata import ProductData
 
-config = config_from_argv()
-with ProductData(config.product) as product_data:
-    response = http.fetch_url(config.url)
-    for line in response.text.strip().split('\n'):
-        items = line.split('|')
-        if len(items) >= 5 and config.first_match(items[1].strip()):
-            version = items[1].strip()
-            try:
-                date = dates.parse_date(items[3])
-                product_data.declare_version(version, date)
-            except Exception as e:
-                logging.exception(f"Could not process release {version} for {config.product}: {e}")
+
+def update(_product: ProductFrontmatter, config: AutoConfig) -> None:
+    with ProductData(config.product) as product_data:
+        response = http.fetch_url(config.url)
+        for line in response.text.strip().split('\n'):
+            items = line.split('|')
+            if len(items) >= 5 and config.first_match(items[1].strip()):
+                version = items[1].strip()
+                try:
+                    date = dates.parse_date(items[3])
+                    product_data.declare_version(version, date)
+                except Exception as e:
+                    logging.exception(f"Could not process release {version} for {config.product}: {e}")

--- a/src/routeros-versions.py
+++ b/src/routeros-versions.py
@@ -2,28 +2,30 @@ import logging
 import re
 
 from bs4 import BeautifulSoup
-from common import dates, http
-from common.releasedata import ProductData, config_from_argv
+
+from src.common import dates, http
+from src.common.endoflife import AutoConfig, ProductFrontmatter
+from src.common.releasedata import ProductData
 
 """Fetches versions from MikroTik RouterOS release notes page.
 
 This script only considers stable and long-term versions, and ignores testing and development versions.
 """
 
-config = config_from_argv()
-with ProductData(config.product) as product_data:
-    content = http.fetch_javascript_url(config.url)
-    soup = BeautifulSoup(content, features="html5lib")
+def update(_product: ProductFrontmatter, config: AutoConfig) -> None:
+    with ProductData(config.product) as product_data:
+        content = http.fetch_javascript_url(config.url)
+        soup = BeautifulSoup(content, features="html5lib")
 
-    for release_line in soup.select("div.grow"):
-        text = re.sub(r'\s+', ' ', release_line.get_text()).strip()
-        parts = text.split(' ')
-        if len(parts) != 3:
-            logging.debug(f"Skipping '{text}', not in expected format")
-            continue
+        for release_line in soup.select("div.grow"):
+            text = re.sub(r'\s+', ' ', release_line.get_text()).strip()
+            parts = text.split(' ')
+            if len(parts) != 3:
+                logging.debug(f"Skipping '{text}', not in expected format")
+                continue
 
-        version = parts[0]
-        channel = parts[1].lower()
-        release_date = dates.parse_date(parts[2])
-        if channel in ["stable", "long-term"]:
-            product_data.declare_version(version, release_date)
+            version = parts[0]
+            channel = parts[1].lower()
+            release_date = dates.parse_date(parts[2])
+            if channel in ["stable", "long-term"]:
+                product_data.declare_version(version, release_date)

--- a/src/rtpengine-releases.py
+++ b/src/rtpengine-releases.py
@@ -1,13 +1,15 @@
-from common import dates, http
-from common.releasedata import ProductData, config_from_argv
+from src.common import dates, http
+from src.common.endoflife import AutoConfig, ProductFrontmatter
+from src.common.releasedata import ProductData
 
-config = config_from_argv()
-with ProductData(config.product) as product_data:
-    data = http.fetch_json(config.url)
-    for release_record in data:
-        release_match = config.first_match(release_record.get("id", ""))
-        if release_match:
-            release_name = config.render(release_match)
-            release = product_data.get_release(release_name)
-            release.set_release_date(dates.parse_date(release_record.get("start")))
-            release.set_eol(dates.parse_date(release_record.get("end")))
+
+def update(_product: ProductFrontmatter, config: AutoConfig) -> None:
+    with ProductData(config.product) as product_data:
+        data = http.fetch_json(config.url)
+        for release_record in data:
+            release_match = config.first_match(release_record.get("id", ""))
+            if release_match:
+                release_name = config.render(release_match)
+                release = product_data.get_release(release_name)
+                release.set_release_date(dates.parse_date(release_record.get("start")))
+                release.set_eol(dates.parse_date(release_record.get("end")))

--- a/src/samsung-security.py
+++ b/src/samsung-security.py
@@ -2,8 +2,9 @@ import logging
 import re
 from datetime import date, datetime, time, timezone
 
-from common import dates, endoflife, http
-from common.releasedata import ProductData, parse_argv
+from src.common import dates, endoflife, http
+from src.common.endoflife import AutoConfig, ProductFrontmatter
+from src.common.releasedata import ProductData
 
 """Detect new models and aggregate EOL data for Samsung Mobile devices.
 
@@ -13,69 +14,69 @@ it retains the date and use it as the model's EOL date.
 
 TODAY = dates.today_at_midnight()
 
-frontmatter, config = parse_argv()
-with ProductData(config.product) as product_data:
-    frontmatter_release_names = frontmatter.get_release_names()
+def update(product: ProductFrontmatter, config: AutoConfig) -> None:
+    with ProductData(config.product) as product_data:
+        frontmatter_release_names = product.get_release_names()
 
-    # Copy EOL dates from frontmatter to product data
-    for frontmatter_release in frontmatter.get_releases():
-        eol = frontmatter_release.get("eol")
-        eol = datetime.combine(eol, time.min, tzinfo=timezone.utc) if isinstance(eol, date) else eol
+        # Copy EOL dates from product to product data
+        for frontmatter_release in product.get_releases():
+            eol = frontmatter_release.get("eol")
+            eol = datetime.combine(eol, time.min, tzinfo=timezone.utc) if isinstance(eol, date) else eol
 
-        release = product_data.get_release(frontmatter_release.get("releaseCycle"))
-        release.set_eol(eol)
+            release = product_data.get_release(frontmatter_release.get("releaseCycle"))
+            release.set_eol(eol)
 
 
-    html = http.fetch_html(config.url)
+        html = http.fetch_html(config.url)
 
-    sections = config.data.get("sections", {})
-    for update_cadence, title in sections.items():
-        title_heading = html.find(string=lambda text, search=title: search in text if text else False)
+        sections = config.data.get("sections", {})
+        for update_cadence, title in sections.items():
+            title_heading = html.find(string=lambda text, search=title: search in text if text else False)
 
-        if title_heading:
-            logging.info(f"Processing '{title_heading}'")
-        else:
-            logging.warning(f"Could not find section with title containing '{title}'")
-            continue
-
-        for item in title_heading.find_next("ul").select("li > ul > li"):
-            models = item.text
-            logging.info(f"Found {models} for {update_cadence} security updates")
-
-            for model in re.split(r',\s*', models):
-                name = endoflife.to_identifier(model)
-                if config.is_excluded(name):
-                    logging.debug(f"Ignoring model '{name}', excluded by configuration")
-                    continue
-
-                release = product_data.get_release(name)
-                release.set_label(model.strip())
-
-                if name in frontmatter_release_names:
-                    frontmatter_release_names.remove(name)
-                    current_eol = release.get_eol()
-                    if current_eol is True or (isinstance(current_eol, datetime) and current_eol <= TODAY):
-                        logging.info(f"Known model {name} is incorrectly marked as EOL, updating eol")
-                        release.set_eol(False)
-                    else:
-                        logging.debug(f"Known model {name} is not EOL, keeping eol as {current_eol}")
-
-                else:
-                    logging.debug(f"Found new model {name}")
-                    release.set_eol(False)
-
-    # the remaining models in frontmatter_release_names are not listed anymore on the Samsung page => they are EOL
-    for eol_model_name in frontmatter_release_names:
-        release = product_data.get_release(eol_model_name)
-        current_eol = release.get_eol()
-        if config.is_excluded(eol_model_name):
-            logging.debug(f"Skipping model {eol_model_name}, excluded by configuration")
-        elif current_eol is False:
-            logging.info(f"Model {eol_model_name} is not EOL, setting eol")
-            release.set_eol(TODAY)
-        elif isinstance(current_eol, datetime):
-            if current_eol > TODAY:
-                logging.info(f"Model {eol_model_name} is not marked as EOL, setting eol as {TODAY}")
-                release.set_eol(TODAY)
+            if title_heading:
+                logging.info(f"Processing '{title_heading}'")
             else:
-                logging.debug(f"Model {eol_model_name} is already EOL, keeping eol as {current_eol}")
+                logging.warning(f"Could not find section with title containing '{title}'")
+                continue
+
+            for item in title_heading.find_next("ul").select("li > ul > li"):
+                models = item.text
+                logging.info(f"Found {models} for {update_cadence} security updates")
+
+                for model in re.split(r',\s*', models):
+                    name = endoflife.to_identifier(model)
+                    if config.is_excluded(name):
+                        logging.debug(f"Ignoring model '{name}', excluded by configuration")
+                        continue
+
+                    release = product_data.get_release(name)
+                    release.set_label(model.strip())
+
+                    if name in frontmatter_release_names:
+                        frontmatter_release_names.remove(name)
+                        current_eol = release.get_eol()
+                        if current_eol is True or (isinstance(current_eol, datetime) and current_eol <= TODAY):
+                            logging.info(f"Known model {name} is incorrectly marked as EOL, updating eol")
+                            release.set_eol(False)
+                        else:
+                            logging.debug(f"Known model {name} is not EOL, keeping eol as {current_eol}")
+
+                    else:
+                        logging.debug(f"Found new model {name}")
+                        release.set_eol(False)
+
+        # the remaining models in frontmatter_release_names are not listed anymore on the Samsung page => they are EOL
+        for eol_model_name in frontmatter_release_names:
+            release = product_data.get_release(eol_model_name)
+            current_eol = release.get_eol()
+            if config.is_excluded(eol_model_name):
+                logging.debug(f"Skipping model {eol_model_name}, excluded by configuration")
+            elif current_eol is False:
+                logging.info(f"Model {eol_model_name} is not EOL, setting eol")
+                release.set_eol(TODAY)
+            elif isinstance(current_eol, datetime):
+                if current_eol > TODAY:
+                    logging.info(f"Model {eol_model_name} is not marked as EOL, setting eol as {TODAY}")
+                    release.set_eol(TODAY)
+                else:
+                    logging.debug(f"Model {eol_model_name} is already EOL, keeping eol as {current_eol}")

--- a/src/silverstripe.py
+++ b/src/silverstripe.py
@@ -1,20 +1,21 @@
-from common import dates, http
-from common.releasedata import ProductData, config_from_argv
+from src.common import dates, http
+from src.common.endoflife import AutoConfig, ProductFrontmatter
+from src.common.releasedata import ProductData
 
 """Fetches Silverstripe releases from https://www.silverstripe.org/software/roadmap/ JSON data."""
 
-config = config_from_argv()
-with ProductData(config.product) as product_data:
-    json = http.fetch_json(config.url)
-    for release_data in json["data"]:
-        release_name = release_data["version"]
-        release = product_data.get_release(release_name)
+def update(_product: ProductFrontmatter, config: AutoConfig) -> None:
+    with ProductData(config.product) as product_data:
+        json = http.fetch_json(config.url)
+        for release_data in json["data"]:
+            release_name = release_data["version"]
+            release = product_data.get_release(release_name)
 
-        release_date_str = release_data.get("releaseDate")
-        release.set_release_date(dates.parse_date_or_month_year_date(release_date_str))
+            release_date_str = release_data.get("releaseDate")
+            release.set_release_date(dates.parse_date_or_month_year_date(release_date_str))
 
-        eoas_date_str = release_data.get("partialSupport")
-        release.set_eoas(dates.parse_date_or_month_year_date(eoas_date_str))
+            eoas_date_str = release_data.get("partialSupport")
+            release.set_eoas(dates.parse_date_or_month_year_date(eoas_date_str))
 
-        eol_date_str = release_data.get("supportEnds")
-        release.set_eol(dates.parse_date_or_month_year_date(eol_date_str))
+            eol_date_str = release_data.get("supportEnds")
+            release.set_eol(dates.parse_date_or_month_year_date(eol_date_str))

--- a/src/splunk.py
+++ b/src/splunk.py
@@ -1,8 +1,10 @@
 import re
 
 from bs4 import BeautifulSoup
-from common import dates, http
-from common.releasedata import ProductData, config_from_argv
+
+from src.common import dates, http
+from src.common.endoflife import AutoConfig, ProductFrontmatter
+from src.common.releasedata import ProductData
 
 VERSION_DATE_PATTERN = re.compile(r"Splunk Enterprise (?P<version>\d+\.\d+(?:\.\d+)*) was (?:first )?released on (?P<date>\w+\s\d\d?,\s\d{4})\.", re.MULTILINE)
 
@@ -31,19 +33,19 @@ def get_latest_minor_versions(versions: list[str]) -> list[str]:
     return latest_versions
 
 
-config = config_from_argv()
-with (ProductData(config.product) as product_data):
-    html = BeautifulSoup(http.fetch_javascript_url(config.url), features="html5lib")
+def update(_product: ProductFrontmatter, config: AutoConfig) -> None:
+    with (ProductData(config.product) as product_data):
+        html = BeautifulSoup(http.fetch_javascript_url(config.url), features="html5lib")
 
-    all_versions = [option['value'] for option in html.select("select#version-select > option")]
-    all_versions = [v for v in all_versions if v != "DataMonitoringAppPreview"]
+        all_versions = [option['value'] for option in html.select("select#version-select > option")]
+        all_versions = [v for v in all_versions if v != "DataMonitoringAppPreview"]
 
-    # Latest minor release notes contains release notes for all previous minor versions.
-    # For example, 9.0.5 release notes also contains release notes for 9.0.0 to 9.0.4.
-    latest_minor_versions = get_latest_minor_versions(all_versions)
-    for url in [f"{config.url}/{v}/ReleaseNotes/MeetSplunk" for v in latest_minor_versions]:
-        response = BeautifulSoup(http.fetch_javascript_url(url, user_agent=http.FIREFOX_USER_AGENT), features="html5lib")
-        for (version_str, date_str) in VERSION_DATE_PATTERN.findall(response.text):
-            version_str = f"{version_str}.0" if len(version_str.split(".")) == 2 else version_str  # convert x.y to x.y.0
-            date = dates.parse_date(date_str)
-            product_data.declare_version(version_str, date)
+        # Latest minor release notes contains release notes for all previous minor versions.
+        # For example, 9.0.5 release notes also contains release notes for 9.0.0 to 9.0.4.
+        latest_minor_versions = get_latest_minor_versions(all_versions)
+        for url in [f"{config.url}/{v}/ReleaseNotes/MeetSplunk" for v in latest_minor_versions]:
+            response = BeautifulSoup(http.fetch_javascript_url(url, user_agent=http.FIREFOX_USER_AGENT), features="html5lib")
+            for (version_str, date_str) in VERSION_DATE_PATTERN.findall(response.text):
+                version_str = f"{version_str}.0" if len(version_str.split(".")) == 2 else version_str  # convert x.y to x.y.0
+                date = dates.parse_date(date_str)
+                product_data.declare_version(version_str, date)

--- a/src/typo3.py
+++ b/src/typo3.py
@@ -1,13 +1,15 @@
-from common import dates, http
-from common.releasedata import ProductData, config_from_argv
+from src.common import dates, http
+from src.common.endoflife import AutoConfig, ProductFrontmatter
+from src.common.releasedata import ProductData
 
-config = config_from_argv()
-with ProductData(config.product) as product_data:
-    data = http.fetch_json(config.url)
-    for v in data:
-        if v['type'] == 'development':
-            continue
 
-        version = v["version"]
-        date = dates.parse_datetime(v["date"], to_utc=False)  # utc kept for now for backwards compatibility
-        product_data.declare_version(version, date)
+def update(_product: ProductFrontmatter, config: AutoConfig) -> None:
+    with ProductData(config.product) as product_data:
+        data = http.fetch_json(config.url)
+        for v in data:
+            if v['type'] == 'development':
+                continue
+
+            version = v["version"]
+            date = dates.parse_datetime(v["date"], to_utc=False)  # utc kept for now for backwards compatibility
+            product_data.declare_version(version, date)

--- a/src/unity.py
+++ b/src/unity.py
@@ -1,5 +1,6 @@
-from common import dates, http
-from common.releasedata import ProductData, config_from_argv
+from src.common import dates, http
+from src.common.endoflife import AutoConfig, ProductFrontmatter
+from src.common.releasedata import ProductData
 
 """Fetches Unity versions from the Unity Editor Release API.
 
@@ -7,31 +8,31 @@ This script fetches stable releases from the Unity API, filtering out alpha, bet
 The API provides paginated results with all Unity versions across different streams (TECH, LTS, BETA, ALPHA).
 """
 
-config = config_from_argv()
-with ProductData(config.product) as product_data:
-    offset = 0
-    limit = 25
+def update(_product: ProductFrontmatter, config: AutoConfig) -> None:
+    with ProductData(config.product) as product_data:
+        offset = 0
+        limit = 25
 
-    while True:
-        url = f"{config.url}?limit={limit}&offset={offset}"
-        data = http.fetch_json(url)
+        while True:
+            url = f"{config.url}?limit={limit}&offset={offset}"
+            data = http.fetch_json(url)
 
-        if 'results' not in data:
-            break
+            if 'results' not in data:
+                break
 
-        for release in data['results']:
-            version = release['version']
+            for release in data['results']:
+                version = release['version']
 
-            # Skip pre-release versions (ALPHA, BETA, etc.)
-            stream = release.get('stream', '')
-            if stream in ('ALPHA', 'BETA'):
-                continue
+                # Skip pre-release versions (ALPHA, BETA, etc.)
+                stream = release.get('stream', '')
+                if stream in ('ALPHA', 'BETA'):
+                    continue
 
-            date = dates.parse_datetime(release['releaseDate'])
-            product_data.declare_version(version, date)
+                date = dates.parse_datetime(release['releaseDate'])
+                product_data.declare_version(version, date)
 
-        # Check if we've reached the end
-        total = data.get('total', 0)
-        offset += limit
-        if offset >= total:
-            break
+            # Check if we've reached the end
+            total = data.get('total', 0)
+            offset += limit
+            if offset >= total:
+                break

--- a/src/unrealircd.py
+++ b/src/unrealircd.py
@@ -1,21 +1,22 @@
 import re
 
-from common import dates, http
-from common.releasedata import ProductData, config_from_argv
+from src.common import dates, http
+from src.common.endoflife import AutoConfig, ProductFrontmatter
+from src.common.releasedata import ProductData
 
 DATE_PATTERN = re.compile(r"\d{4}-\d{2}-\d{2}")
 
-config = config_from_argv()
-with ProductData(config.product) as product_data:
-    wikicode = http.fetch_markdown(config.url)
+def update(_product: ProductFrontmatter, config: AutoConfig) -> None:
+    with ProductData(config.product) as product_data:
+        wikicode = http.fetch_markdown(config.url)
 
-    for tr in wikicode.ifilter_tags(matches=lambda node: node.tag == "tr"):
-        items = tr.contents.filter_tags(matches=lambda node: node.tag == "td")
-        if len(items) < 2:
-            continue
+        for tr in wikicode.ifilter_tags(matches=lambda node: node.tag == "tr"):
+            items = tr.contents.filter_tags(matches=lambda node: node.tag == "td")
+            if len(items) < 2:
+                continue
 
-        version = items[0].__strip__()
-        date_str = items[1].__strip__()
-        if config.first_match(version) and DATE_PATTERN.match(date_str):
-            date = dates.parse_date(date_str)
-            product_data.declare_version(version, date)
+            version = items[0].__strip__()
+            date_str = items[1].__strip__()
+            if config.first_match(version) and DATE_PATTERN.match(date_str):
+                date = dates.parse_date(date_str)
+                product_data.declare_version(version, date)

--- a/src/veeam.py
+++ b/src/veeam.py
@@ -1,8 +1,9 @@
 import logging
 import re
 
-from common import dates, http
-from common.releasedata import ProductData, config_from_argv
+from src.common import dates, http
+from src.common.endoflife import AutoConfig, ProductFrontmatter
+from src.common.releasedata import ProductData
 
 """Fetches Veeam products versions from https://www.veeam.com.
 
@@ -10,31 +11,31 @@ This script takes a single argument which is the url of the versions page on htt
 such as `https://www.veeam.com/kb2680`.
 """
 
-config = config_from_argv()
-with ProductData(config.product) as product_data:
-    html = http.fetch_html(config.url)
+def update(_product: ProductFrontmatter, config: AutoConfig) -> None:
+    with ProductData(config.product) as product_data:
+        html = http.fetch_html(config.url)
 
-    version_column = config.data.get("version_column", "Build Number").lower()
-    date_column = config.data.get("date_column", "Release Date").lower()
-    for table in html.find_all("table"):
-        headers = [header.get_text().strip().lower() for header in table.find("tr").find_all("td")]
-        if version_column not in headers or date_column not in headers:
-            logging.warning("Skipping table with headers %s as it does not contains '%s' or '%s'",
-                            headers, version_column, date_column)
-            continue
-
-        version_index = headers.index(version_column)
-        date_index = headers.index(date_column)
-        for row in table.find_all("tr")[1:]:
-            cells = row.find_all("td")
-            if len(cells) <= max(version_index, date_index):
+        version_column = config.data.get("version_column", "Build Number").lower()
+        date_column = config.data.get("date_column", "Release Date").lower()
+        for table in html.find_all("table"):
+            headers = [header.get_text().strip().lower() for header in table.find("tr").find_all("td")]
+            if version_column not in headers or date_column not in headers:
+                logging.warning("Skipping table with headers %s as it does not contains '%s' or '%s'",
+                                headers, version_column, date_column)
                 continue
 
-            date_str = cells[date_index].get_text().strip()
-            if not date_str or date_str == "-":
-                continue
+            version_index = headers.index(version_column)
+            date_index = headers.index(date_column)
+            for row in table.find_all("tr")[1:]:
+                cells = row.find_all("td")
+                if len(cells) <= max(version_index, date_index):
+                    continue
 
-            # whitespaces in version numbers are replaced with dashes
-            version = re.sub(r'\s+', "-", cells[version_index].get_text().strip())
-            date = dates.parse_date(date_str)
-            product_data.declare_version(version, date)
+                date_str = cells[date_index].get_text().strip()
+                if not date_str or date_str == "-":
+                    continue
+
+                # whitespaces in version numbers are replaced with dashes
+                version = re.sub(r'\s+', "-", cells[version_index].get_text().strip())
+                date = dates.parse_date(date_str)
+                product_data.declare_version(version, date)

--- a/src/version_table.py
+++ b/src/version_table.py
@@ -2,8 +2,10 @@ import logging
 import re
 
 from bs4 import BeautifulSoup
-from common import dates, http
-from common.releasedata import ProductData, config_from_argv
+
+from src.common import dates, http
+from src.common.endoflife import AutoConfig, ProductFrontmatter
+from src.common.releasedata import ProductData
 
 """Fetch version-level data from an HTML table in a web page.
 
@@ -33,60 +35,60 @@ def normalize_header(value: str) -> str:
     return WHITESPACE_PATTERN.sub(' ', value).strip().lower()
 
 
-config = config_from_argv()
-with ProductData(config.product) as product_data:
-    table_selector: str = config.data.get("selector", "table")
-    header_row_selector: str = config.data.get("header_selector", "thead tr")
-    rows_selector: str = config.data.get("rows_selector", "tbody tr")
-    cells_selector: str = "td, th"
+def update(_product: ProductFrontmatter, config: AutoConfig) -> None:
+    with ProductData(config.product) as product_data:
+        table_selector: str = config.data.get("selector", "table")
+        header_row_selector: str = config.data.get("header_selector", "thead tr")
+        rows_selector: str = config.data.get("rows_selector", "tbody tr")
+        cells_selector: str = "td, th"
 
-    version_name_column: str = normalize_header(config.data["name_column"])
-    version_date_column: str = normalize_header(config.data["date_column"])
+        version_name_column: str = normalize_header(config.data["name_column"])
+        version_date_column: str = normalize_header(config.data["date_column"])
 
-    user_agent: str = config.data.get("user_agent", http.ENDOFLIFE_BOT_USER_AGENT)
-    render_js: bool = config.data.get("render_javascript", False)
-    render_js_wait_until: str | None = config.data.get("render_javascript_wait_until", None)
-    render_js_wait_for: str | None = config.data.get("render_javascript_wait_for", None)
-    render_js_click_selector: str | None = config.data.get("render_javascript_click_selector", None)
+        user_agent: str = config.data.get("user_agent", http.ENDOFLIFE_BOT_USER_AGENT)
+        render_js: bool = config.data.get("render_javascript", False)
+        render_js_wait_until: str | None = config.data.get("render_javascript_wait_until", None)
+        render_js_wait_for: str | None = config.data.get("render_javascript_wait_for", None)
+        render_js_click_selector: str | None = config.data.get("render_javascript_click_selector", None)
 
-    if render_js:
-        response_text = http.fetch_javascript_url(config.url, user_agent=user_agent, wait_until=render_js_wait_until,
-                                                  wait_for=render_js_wait_for, click_selector=render_js_click_selector)
-    else:
-        response_text = http.fetch_url(config.url, user_agent=user_agent).text
-    soup = BeautifulSoup(response_text, features="html5lib")
+        if render_js:
+            response_text = http.fetch_javascript_url(config.url, user_agent=user_agent, wait_until=render_js_wait_until,
+                                                      wait_for=render_js_wait_for, click_selector=render_js_click_selector)
+        else:
+            response_text = http.fetch_url(config.url, user_agent=user_agent).text
+        soup = BeautifulSoup(response_text, features="html5lib")
 
-    for table in soup.select(table_selector):
-        header_row = table.select_one(header_row_selector)
-        if not header_row:
-            logging.info(f"skipping table with attributes {table.attrs}: no header row found")
-            continue
+        for table in soup.select(table_selector):
+            header_row = table.select_one(header_row_selector)
+            if not header_row:
+                logging.info(f"skipping table with attributes {table.attrs}: no header row found")
+                continue
 
-        headers = [normalize_header(th.get_text()) for th in header_row.select(cells_selector)]
-        logging.info(f"processing table with headers {headers}")
+            headers = [normalize_header(th.get_text()) for th in header_row.select(cells_selector)]
+            logging.info(f"processing table with headers {headers}")
 
-        try:
-            version_name_index = headers.index(version_name_column)
-            version_date_index = headers.index(version_date_column)
-            min_columns_count = max([version_name_index, version_date_index]) + 1
+            try:
+                version_name_index = headers.index(version_name_column)
+                version_date_index = headers.index(version_date_column)
+                min_columns_count = max([version_name_index, version_date_index]) + 1
 
-            for row in table.select(rows_selector):
-                cells = [cell.get_text().strip() for cell in row.select(cells_selector)]
-                if len(cells) < min_columns_count:
-                    logging.debug(f"skipping row {cells}: not enough columns")
-                    continue
+                for row in table.select(rows_selector):
+                    cells = [cell.get_text().strip() for cell in row.select(cells_selector)]
+                    if len(cells) < min_columns_count:
+                        logging.debug(f"skipping row {cells}: not enough columns")
+                        continue
 
-                raw_version_name = cells[version_name_index]
-                version_match = config.first_match(raw_version_name)
-                if not version_match:
-                    logging.debug(f"skipping row {cells}: invalid release cycle '{raw_version_name}', "
-                                  f"should match one of {config.include_version_patterns} "
-                                  f"and not match all of {config.exclude_version_patterns}")
-                    continue
+                    raw_version_name = cells[version_name_index]
+                    version_match = config.first_match(raw_version_name)
+                    if not version_match:
+                        logging.debug(f"skipping row {cells}: invalid release cycle '{raw_version_name}', "
+                                      f"should match one of {config.include_version_patterns} "
+                                      f"and not match all of {config.exclude_version_patterns}")
+                        continue
 
-                version_name = config.render(version_match)
-                version_date = dates.parse__datetime_or_date_or_month_year_date(cells[version_date_index])
-                product_data.declare_version(version_name, version_date)
+                    version_name = config.render(version_match)
+                    version_date = dates.parse__datetime_or_date_or_month_year_date(cells[version_date_index])
+                    product_data.declare_version(version_name, version_date)
 
-        except ValueError as e:
-            logging.info(f"skipping table with headers {headers}: {e}")
+            except ValueError as e:
+                logging.info(f"skipping table with headers {headers}: {e}")

--- a/src/virtualbox-releases.py
+++ b/src/virtualbox-releases.py
@@ -1,34 +1,35 @@
 import logging
 import re
 
-from common import dates, http
-from common.releasedata import ProductData, config_from_argv
+from src.common import dates, http
+from src.common.endoflife import AutoConfig, ProductFrontmatter
+from src.common.releasedata import ProductData
 
 """Fetches releases from VirtualBox download page."""
 
 EOL_REGEX = re.compile(r"^\(no longer supported, support ended (?P<value>\d{4}/\d{2})\)$")
 
-config = config_from_argv()
-with ProductData(config.product) as product_data:
-    html = http.fetch_html(config.url)
+def update(_product: ProductFrontmatter, config: AutoConfig) -> None:
+    with ProductData(config.product) as product_data:
+        html = http.fetch_html(config.url)
 
-    for li in html.select_one("#DownloadVirtualBoxOldBuilds + ul").find_all("li"):
-        li_text = li.find("a").text.strip()
+        for li in html.select_one("#DownloadVirtualBoxOldBuilds + ul").find_all("li"):
+            li_text = li.find("a").text.strip()
 
-        release_match = config.first_match(li_text)
-        if not release_match:
-            logging.info(f"Skipping '{li_text}': does not match expected pattern")
-            continue
+            release_match = config.first_match(li_text)
+            if not release_match:
+                logging.info(f"Skipping '{li_text}': does not match expected pattern")
+                continue
 
-        release_name = release_match.group("value")
-        release = product_data.get_release(release_name)
+            release_name = release_match.group("value")
+            release = product_data.get_release(release_name)
 
-        eol_text = li.find("em").text.lower().strip()
-        eol_match = EOL_REGEX.match(eol_text)
-        if not eol_match:
-            logging.info(f"Ignoring '{eol_text}': does not match {EOL_REGEX}")
-            continue
+            eol_text = li.find("em").text.lower().strip()
+            eol_match = EOL_REGEX.match(eol_text)
+            if not eol_match:
+                logging.info(f"Ignoring '{eol_text}': does not match {EOL_REGEX}")
+                continue
 
-        eol_date_str = eol_match.group("value")
-        eol_date = dates.parse_month_year_date(eol_date_str)
-        release.set_eol(eol_date)
+            eol_date_str = eol_match.group("value")
+            eol_date = dates.parse_month_year_date(eol_date_str)
+            release.set_eol(eol_date)

--- a/src/virtualbox-versions.py
+++ b/src/virtualbox-versions.py
@@ -1,18 +1,19 @@
-from common import dates, http
-from common.releasedata import ProductData, config_from_argv
+from src.common import dates, http
+from src.common.endoflife import AutoConfig, ProductFrontmatter
+from src.common.releasedata import ProductData
 
 """Fetches versions from download.virtualbox.org."""
 
-config = config_from_argv()
-with ProductData(config.product) as product_data:
-    html = http.fetch_html(config.url)
+def update(_product: ProductFrontmatter, config: AutoConfig) -> None:
+    with ProductData(config.product) as product_data:
+        html = http.fetch_html(config.url)
 
-    for a in html.select("a"):
-        href = a["href"]
+        for a in html.select("a"):
+            href = a["href"]
 
-        version_match = config.first_match(href)
-        if version_match:
-            version = config.render(version_match)
-            date_str = a.next_sibling.strip().split(" ")[0]
-            date = dates.parse_date(date_str)
-            product_data.declare_version(version, date)
+            version_match = config.first_match(href)
+            if version_match:
+                version = config.render(version_match)
+                date_str = a.next_sibling.strip().split(" ")[0]
+                date = dates.parse_date(date_str)
+                product_data.declare_version(version, date)

--- a/src/visual-studio.py
+++ b/src/visual-studio.py
@@ -1,25 +1,27 @@
-from common import dates, http
-from common.releasedata import ProductData, config_from_argv
+from src.common import dates, http
+from src.common.endoflife import AutoConfig, ProductFrontmatter
+from src.common.releasedata import ProductData
 
-config = config_from_argv()
-with ProductData(config.product) as product_data:
-    html = http.fetch_html(config.url)
 
-    for table in html.find_all("table"):
-        headers = [th.get_text().strip().lower() for th in table.find_all("th")]
-        if "version" not in headers or "release date" not in headers:
-            continue
+def update(_product: ProductFrontmatter, config: AutoConfig) -> None:
+    with ProductData(config.product) as product_data:
+        html = http.fetch_html(config.url)
 
-        version_index = headers.index("version")
-        date_index = headers.index("release date")
-        for row in table.findAll("tr"):
-            cells = row.findAll("td")
-            if len(cells) < (max(version_index, date_index) + 1):
+        for table in html.find_all("table"):
+            headers = [th.get_text().strip().lower() for th in table.find_all("th")]
+            if "version" not in headers or "release date" not in headers:
                 continue
 
-            version = cells[version_index].get_text().strip()
-            date = cells[date_index].get_text().strip()
-            date = dates.parse_date(date)
+            version_index = headers.index("version")
+            date_index = headers.index("release date")
+            for row in table.findAll("tr"):
+                cells = row.findAll("td")
+                if len(cells) < (max(version_index, date_index) + 1):
+                    continue
 
-            if date and version and config.first_match(version):
-                product_data.declare_version(version, date)
+                version = cells[version_index].get_text().strip()
+                date = cells[date_index].get_text().strip()
+                date = dates.parse_date(date)
+
+                if date and version and config.first_match(version):
+                    product_data.declare_version(version, date)

--- a/update-release-data.py
+++ b/update-release-data.py
@@ -1,4 +1,5 @@
 import argparse
+import importlib
 import json
 import logging
 import os
@@ -93,27 +94,18 @@ def __revert_data(product: ProductFrontmatter) -> None:
     logging.warning(f"reverted changes in {release_data_path}")
 
 
-# Defensive upper bound on a single child script's execution time. Child scripts are expected to enforce their
-# own (tighter) timeouts internally, but this acts as a safety net in case one doesn't, so a single hung script
-# can't block the entire CI job indefinitely.
-CHILD_SCRIPT_TIMEOUT_SECONDS = 300
-
-
 def __run_script(product: ProductFrontmatter, config: AutoConfig, summary: ScriptExecutionSummary) -> bool:
     script = SCRIPT_DIR / SRC_DIR / config.script
 
     logging.info(f"start running {script.name} for {config}")
     start = time.perf_counter()
 
-    # timeout is handled in child scripts; CHILD_SCRIPT_TIMEOUT_SECONDS is only a defensive fallback
-    script_args = [sys.executable, script, "-p", product.path, "-m", str(config.method), "-u", str(config.url)]
-    script_args = script_args + ["-v"] if logging.getLogger().isEnabledFor(logging.DEBUG) else script_args
-
     try:
-        child = subprocess.run(script_args, timeout=CHILD_SCRIPT_TIMEOUT_SECONDS)
-        success = child.returncode == 0
-    except subprocess.TimeoutExpired:
-        logging.error(f"{script} for {config} timed out after {CHILD_SCRIPT_TIMEOUT_SECONDS}s")
+        module = importlib.import_module(f"src.{config.method}")
+        module.update(product, config)
+        success = True
+    except Exception:
+        logging.exception(f"{script} for {config} failed")
         success = False
 
     elapsed_seconds = time.perf_counter() - start


### PR DESCRIPTION
Instead of spawning a Python subprocess per auto-update script (`src/*.py`), update-release-data.py now dynamically imports each script as a module (`importlib.import_module`) and calls a well-defined `update(product, config)` entry point directly.

- All scripts under `src/*.py`: convert top-level, argparse-driven code into `def update(product: ProductFrontmatter, config: AutoConfig) -> None`.
- `update-release-data.py`: replace `subprocess.run([sys.executable, script, ...])` with `importlib.import_module(config.method)` + `module.update(...)`

This removes one Python interpreter startup per script per product, simplifies error reporting (real tracebacks instead of subprocess exit codes), and overall speed up the whole execution (a few minutes are saved)..