### PR TITLE
[oracle-jdk] Fix date parsing: use 'td, th' selector to handle <th> date cells

### DIFF
--- a/src/oracle-jdk.py
+++ b/src/oracle-jdk.py
@@ -15,7 +15,7 @@ with ProductData(config.product) as product_data:
         version_cell = row.select_one('td.anchor')
         if version_cell:
             version = version_cell.attrs['id']
-            date_str = row.select('td')[1].text
+            date_str = row.select('td, th')[1].text
             date = dates.parse_date(date_str) if date_str else previous_date
             product_data.declare_version(version, date)
             previous_date = date


### PR DESCRIPTION
The live ops.java/releases page uses <th> for the Date column in every data row. row.select('td')[1] skipped these <th> cells, returning the Type column ('CPU') instead of the date, causing 'ValueError: CPU could not be parsed as a date'.

Changed to row.select('td, th')[1] to include both cell types.