### PR TITLE
[unity] Improve script to load pages in parallel

### DIFF
--- a/src/unity.py
+++ b/src/unity.py
@@ -8,31 +8,29 @@ This script fetches stable releases from the Unity API, filtering out alpha, bet
 The API provides paginated results with all Unity versions across different streams (TECH, LTS, BETA, ALPHA).
 """
 
+def declare_releases(product_data: ProductData, data: dict) -> None:
+    for release in data.get('results', []):
+        version = release['version']
+
+        # Skip pre-release versions (ALPHA, BETA, etc.)
+        stream = release.get('stream', '')
+        if stream in ('ALPHA', 'BETA'):
+            continue
+
+        date = dates.parse_datetime(release['releaseDate'])
+        product_data.declare_version(version, date)
+
+
 def update(_product: ProductFrontmatter, config: AutoConfig) -> None:
     with ProductData(config.product) as product_data:
-        offset = 0
         limit = 25
 
-        while True:
-            url = f"{config.url}?limit={limit}&offset={offset}"
-            data = http.fetch_json(url)
+        # Fetch the first page to determine how many releases there are in total.
+        data = http.fetch_json(f"{config.url}?limit={limit}&offset=0")
+        total = data.get('total', 0)
+        declare_releases(product_data, data)
 
-            if 'results' not in data:
-                break
-
-            for release in data['results']:
-                version = release['version']
-
-                # Skip pre-release versions (ALPHA, BETA, etc.)
-                stream = release.get('stream', '')
-                if stream in ('ALPHA', 'BETA'):
-                    continue
-
-                date = dates.parse_datetime(release['releaseDate'])
-                product_data.declare_version(version, date)
-
-            # Check if we've reached the end
-            total = data.get('total', 0)
-            offset += limit
-            if offset >= total:
-                break
+        # Fetch the remaining pages in parallel.
+        urls = [f"{config.url}?limit={limit}&offset={offset}" for offset in range(limit, total, limit)]
+        for response in http.fetch_urls(urls):
+            declare_releases(product_data, response.json())


### PR DESCRIPTION
Instead of fetching Unity releases one page at a time, first fetch the first page to learn the total number of releases, then fetch all remaining pages concurrently via `http.fetch_urls`.