### PR TITLE
[red-hat-jboss-eap-8] Fix version name derivation

### DIFF
--- a/src/red-hat-jboss-eap-8.py
+++ b/src/red-hat-jboss-eap-8.py
@@ -10,10 +10,14 @@ def update(_product: ProductFrontmatter, config: AutoConfig) -> None:
     with ProductData(config.product) as product_data:
         xml = http.fetch_xml(config.url)
 
-        versioning = xml.getElementsByTagName("metadata")[0].getElementsByTagName("versioning")[0]
+        metadata = xml.getElementsByTagName("metadata")[0]
+        versioning = metadata.getElementsByTagName("versioning")[0]
 
+        artifact_id = metadata.getElementsByTagName("artifactId")[0].firstChild.nodeValue
         latest_str = versioning.getElementsByTagName("latest")[0].firstChild.nodeValue
-        latest_name = "8.0." + re.match(r"^..(.*)\.GA", latest_str).group(1)
+
+        version_prefix = artifact_id.removeprefix("eap-")
+        latest_name = version_prefix + "." + re.match(r"^1\.(.*)\.GA", latest_str).group(1)
 
         latest_date_str = versioning.getElementsByTagName("lastUpdated")[0].firstChild.nodeValue
         latest_date = dates.parse_datetime(latest_date_str)


### PR DESCRIPTION
The script hardcoded "8.0." as the version prefix, assuming the EAP version. It now reads the artifactId (e.g. "eap-8.0") from the Maven metadata and derives the prefix from it, so the version name stays in sync with the artifact instead of being guessed.

Also tightened the regex to explicitly drop the channel's leading "1." major version instead of blindly skipping the first two characters of the latest version string.

Relates to https://github.com/endoflife-date/endoflife.date/issues/10491.