### PR TITLE
Process products in parallel in update-release-data.py

### DIFF
--- a/src/common/gha.py
+++ b/src/common/gha.py
@@ -45,14 +45,3 @@ class GitHubStepSummary:
         if var_exists:
             with open(os.environ["GITHUB_STEP_SUMMARY"], 'a') as github_step_summary:  # NOQA: PTH123
                 print(self.value, file=github_step_summary)
-
-
-class GitHubGroup:
-    def __init__(self, name: str) -> None:
-        self.name = name
-
-    def __enter__(self) -> None:
-        print(f"::group::{self.name}")
-
-    def __exit__(self, exc_type: any, exc_value: any, traceback: any) -> None:
-        print("::endgroup::")

--- a/update-release-data.py
+++ b/update-release-data.py
@@ -5,14 +5,16 @@ import logging
 import os
 import subprocess
 import sys
+import threading
 import time
 from collections import defaultdict
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
 from deepdiff import DeepDiff
 
 from src.common.endoflife import AutoConfig, ProductFrontmatter, list_products
-from src.common.gha import GitHubGroup, GitHubOutput, GitHubStepSummary
+from src.common.gha import GitHubOutput, GitHubStepSummary
 from src.common.releasedata import DATA_DIR, SRC_DIR
 
 SCRIPT_DIR = Path(__file__).resolve().parent
@@ -22,9 +24,23 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 COPY_PRODUCT_RELEASES_METHOD = "_copy_product_releases"
 REMOVE_INVALID_RELEASES_METHOD = "_remove_invalid_releases"
 
+# Default number of products processed concurrently by run_scripts.
+DEFAULT_WORKERS = 4
+
+# Tracks which product (if any) the current thread is processing, so that log lines can be tagged
+# accordingly (see ProductLogFilter below).
+_log_context = threading.local()
+
+
+class ProductLogFilter(logging.Filter):
+    def filter(self, record: logging.LogRecord) -> bool:
+        record.product = getattr(_log_context, "product", "main")
+        return True
+
 
 class ScriptExecutionSummary:
     def __init__(self) -> None:
+        self._lock = threading.Lock()
         self.success_by_product = defaultdict(lambda: True)
         self.success_by_script = defaultdict(lambda: True)
         self.durations_by_product = defaultdict(float)
@@ -33,12 +49,13 @@ class ScriptExecutionSummary:
         self.products_by_script = defaultdict(list)
 
     def register(self, script: str, product: str, duration: float, success: bool) -> None:
-        self.success_by_product[product] = self.success_by_product[product] and success
-        self.success_by_script[script] = self.success_by_script[script] and success
-        self.durations_by_product[product] += duration
-        self.durations_by_script[script] += duration
-        self.scripts_by_product[product].append(script)
-        self.products_by_script[script].append(product)
+        with self._lock:
+            self.success_by_product[product] = self.success_by_product[product] and success
+            self.success_by_script[script] = self.success_by_script[script] and success
+            self.durations_by_product[product] += duration
+            self.durations_by_script[script] += duration
+            self.scripts_by_product[product].append(script)
+            self.products_by_script[script].append(product)
 
     def print_summary(self, summary: GitHubStepSummary, min_duration: float = 3) -> None:
         summary.println("## Script execution summary\n")
@@ -68,10 +85,9 @@ class ScriptExecutionSummary:
 
 
 def install_playwright() -> None:
-    with GitHubGroup("Install Playwright"):
-        logging.info("Installing Playwright")
-        subprocess.run(['playwright', 'install', 'chromium'], timeout=120, check=True)
-        logging.info("Playwright installed")
+    logging.info("Installing Playwright")
+    subprocess.run(['playwright', 'install', 'chromium'], timeout=120, check=True)
+    logging.info("Playwright installed")
 
 
 def __product_data_path(product: ProductFrontmatter) -> Path:
@@ -117,37 +133,57 @@ def __run_script(product: ProductFrontmatter, config: AutoConfig, summary: Scrip
     return success
 
 
-def run_scripts(summary: GitHubStepSummary, products: list[ProductFrontmatter], force: bool = False) -> bool:
-    exec_summary = ScriptExecutionSummary()
-
-    for product in products:
+def __process_product(product: ProductFrontmatter, force: bool, exec_summary: ScriptExecutionSummary) -> None:
+    _log_context.product = product.name
+    try:
         if not product.has_auto_configs():
-            continue # skip products without auto configs
+            return  # skip products without auto configs
 
         if product.is_auto_update_disabled() and not force:
             logging.info(f"skipping {product.name} as auto update is disabled")
-            continue
+            return
 
         # Add default configs
         configs = product.auto_configs()
         configs = [AutoConfig(product.name, {COPY_PRODUCT_RELEASES_METHOD: ""})] + configs
         configs = configs + [AutoConfig(product.name, {REMOVE_INVALID_RELEASES_METHOD: ""})]
 
-        with GitHubGroup(product.name):
-            try:
-                __delete_data(product)
-                for config in configs:
-                    if config.is_disabled() and not force:
-                        logging.info(f"skipping script {config.script} for {product.name} as it is disabled")
-                        continue
+        logging.info(f"processing {product.name}")
+        try:
+            __delete_data(product)
+            for config in configs:
+                if config.is_disabled() and not force:
+                    logging.info(f"skipping script {config.script} for {product.name} as it is disabled")
+                    continue
 
-                    success = __run_script(product, config, exec_summary)
-                    if not success:
-                        __revert_data(product)
-                        break  # stop running scripts for this product
+                success = __run_script(product, config, exec_summary)
+                if not success:
+                    __revert_data(product)
+                    break  # stop running scripts for this product
 
-            except Exception:
-                logging.exception(f"Skipping {product.name}, there was an error while running its scripts")
+        except Exception:
+            logging.exception(f"Skipping {product.name}, there was an error while running its scripts")
+    finally:
+        _log_context.product = "main"
+
+
+def process_products(summary: GitHubStepSummary, products: list[ProductFrontmatter], force: bool = False,
+                     workers: int = DEFAULT_WORKERS) -> bool:
+    exec_summary = ScriptExecutionSummary()
+
+    with ThreadPoolExecutor(max_workers=workers) as executor:
+        futures = {executor.submit(__process_product, product, force, exec_summary): product for product in products}
+        try:
+            for future in as_completed(futures):
+                product = futures[future]
+                try:
+                    future.result()
+                except Exception:
+                    logging.exception(f"Unexpected error processing {product.name}")
+        except KeyboardInterrupt:
+            logging.warning("Interrupted, cancelling pending products (already-running ones will finish)...")
+            executor.shutdown(wait=True, cancel_futures=True)
+            raise
 
     exec_summary.print_summary(summary)
     return exec_summary.any_failure()
@@ -222,33 +258,41 @@ if __name__ == "__main__":
     parser.add_argument('product', nargs='?', help='restrict update to the given product')
     parser.add_argument('-p', '--product-dir', required=True, help='path to the product directory')
     parser.add_argument('-f', '--force', action='store_true', help='force update even if auto update is disabled')
+    parser.add_argument('-w', '--workers', type=int, default=DEFAULT_WORKERS,
+                        help=f'number of products to process concurrently (default: {DEFAULT_WORKERS})')
     parser.add_argument('-v', '--verbose', action='store_true',
                         default=os.environ.get('ACTIONS_STEP_DEBUG') == 'true',
                         help='enable verbose logging (automatically enabled when ACTIONS_STEP_DEBUG is set)')
     args = parser.parse_args()
 
-    logging.basicConfig(format=logging.BASIC_FORMAT, level=(logging.DEBUG if args.verbose else logging.INFO), stream=sys.stdout)
+    logging.basicConfig(format="%(levelname)s [%(product)s]: %(message)s",
+                        level=(logging.DEBUG if args.verbose else logging.INFO), stream=sys.stdout)
+    logging.getLogger().handlers[0].addFilter(ProductLogFilter())
     install_playwright()
 
     products_dir = Path(args.product_dir)
     products_list = list_products(products_dir, args.product)
 
-    with GitHubStepSummary() as step_summary:
-        some_script_failed = run_scripts(step_summary, products_list, force=args.force)
-        updated_products = get_updated_products()
+    try:
+        with GitHubStepSummary() as step_summary:
+            some_script_failed = process_products(step_summary, products_list, force=args.force, workers=args.workers)
+            updated_products = get_updated_products()
 
-        step_summary.println("## Update summary\n")
-        if updated_products:
-            new_files_content = load_products_json(updated_products)
-            subprocess.run(['git', 'stash', '--all', '--quiet'], timeout=10, check=True, cwd=SCRIPT_DIR)
-            try:
-                old_files_content = load_products_json(updated_products)
-            finally:
-                # Always try to restore the stash, even if reading the old content failed above, so we never
-                # leave the working tree in a half-stashed state.
-                subprocess.run(['git', 'stash', 'pop', '--quiet'], timeout=10, check=True, cwd=SCRIPT_DIR)
-            generate_commit_message(old_files_content, new_files_content, step_summary)
-        else:
-            step_summary.println("No update")
+            step_summary.println("## Update summary\n")
+            if updated_products:
+                new_files_content = load_products_json(updated_products)
+                subprocess.run(['git', 'stash', '--all', '--quiet'], timeout=10, check=True, cwd=SCRIPT_DIR)
+                try:
+                    old_files_content = load_products_json(updated_products)
+                finally:
+                    # Always try to restore the stash, even if reading the old content failed above, so we never
+                    # leave the working tree in a half-stashed state.
+                    subprocess.run(['git', 'stash', 'pop', '--quiet'], timeout=10, check=True, cwd=SCRIPT_DIR)
+                generate_commit_message(old_files_content, new_files_content, step_summary)
+            else:
+                step_summary.println("No update")
+    except KeyboardInterrupt:
+        logging.warning("Interrupted by user, exiting")
+        sys.exit(130)  # 128 + SIGINT, conventional exit code for Ctrl-C
 
     sys.exit(1 if some_script_failed else 0)


### PR DESCRIPTION
`update-release-data.py` was processing hundreds of products strictly sequentially, even though the work is almost entirely I/O-bound (HTTP requests, occasional Playwright/Chromium page loads). Each product also only reads/writes its own `releases/{name}.json` file, so there was no reason for products to wait on each other — we were paying for round-trip latency to dozens of external sites one at a time instead of overlapping it.

This changes the following:

- **Parallel product processing**: products are now processed concurrently via a `ThreadPoolExecutor` (stdlib, no new dependency), configurable with `-w/--workers` (default `4`). Scripts *within* a single product still run sequentially, since they build cumulatively on the same release data — only the work *across* products is parallelized, which is safe because each product's release data lives in its own file.
- **Thread-safe summary tracking**: `ScriptExecutionSummary.register()` is now guarded by a lock, since it's mutated from multiple worker threads.
- **Readable concurrent logs**: log lines are now tagged with `[product-name]` (or `[main]` outside per-product processing) via a lightweight thread-local + logging filter, so interleaved output from concurrent products stays attributable. This replaces the old `GitHubGroup` (`::group::`/`::endgroup::`) wrapping, which can't survive interleaved concurrent writes and would otherwise render as broken, overlapping collapsible sections in the Actions log.
- **Graceful Ctrl-C handling**: interrupting the script cancels any product tasks that haven't started yet (already-running ones are allowed to finish, since Python can't forcibly kill a thread blocked in I/O) and exits with the conventional `130` code, instead of leaving a raw traceback or an unresponsive terminal.

Processing all products in parallel does not change the behavior of the script: the output data is the same. But a full run completes in a fraction of the wall-clock time: a 3-4 minutes vs. 10-15 minutes.
