### PR TITLE
Improve logging with ANSI colors in terminal and GitHub Actions

### DIFF
--- a/src/atlassian_eol.py
+++ b/src/atlassian_eol.py
@@ -14,7 +14,7 @@ This script takes a selector argument which is the product title identifier on t
 
 def update(_product: ProductFrontmatter, config: AutoConfig) -> None:
     with ProductData(config.product) as product_data:
-        content = http.fetch_javascript_url(config.url)
+        content = http.fetch_javascript_url(config.url, wait_until='networkidle')
         soup = BeautifulSoup(content, features="html5lib")
 
         # Find the section with the EOL dates

--- a/src/common/terminal.py
+++ b/src/common/terminal.py
@@ -1,0 +1,26 @@
+import logging
+
+# ANSI SGR color codes used when running interactively in a terminal.
+ANSI_RESET = "\033[0m"
+ANSI_COLOR_BY_LEVEL = {
+    logging.DEBUG: "\033[2m",     # dim
+    logging.WARNING: "\033[33m",  # yellow
+    logging.ERROR: "\033[31m",    # red
+    logging.CRITICAL: "\033[31m", # red
+}
+
+
+class TerminalColorLogFormatter(logging.Formatter):
+    """Colors log lines using ANSI escape codes, for a nicer experience when running interactively in a
+    terminal. Intended to be used only when output is attached to an actual terminal (e.g. based on
+    sys.stdout.isatty()), so that piped/redirected output is not polluted with escape codes.
+    """
+
+    def format(self, record: logging.LogRecord) -> str:  # noqa: A003 - logging.Formatter protocol method
+        message = super().format(record)
+
+        color = ANSI_COLOR_BY_LEVEL.get(record.levelno)
+        if not color:
+            return message
+
+        return f"{color}{message}{ANSI_RESET}"

--- a/update-release-data.py
+++ b/update-release-data.py
@@ -16,6 +16,7 @@ from deepdiff import DeepDiff
 from src.common.endoflife import AutoConfig, ProductFrontmatter, list_products
 from src.common.gha import GitHubOutput, GitHubStepSummary
 from src.common.releasedata import DATA_DIR, SRC_DIR
+from src.common.terminal import TerminalColorLogFormatter
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 
@@ -265,9 +266,16 @@ if __name__ == "__main__":
                         help='enable verbose logging (automatically enabled when ACTIONS_STEP_DEBUG is set)')
     args = parser.parse_args()
 
-    logging.basicConfig(format="%(levelname)s [%(product)s]: %(message)s",
-                        level=(logging.DEBUG if args.verbose else logging.INFO), stream=sys.stdout)
-    logging.getLogger().handlers[0].addFilter(ProductLogFilter())
+    log_format = "%(levelname)s [%(product)s]: %(message)s"
+    if os.environ.get("GITHUB_ACTIONS") == "true" or sys.stdout.isatty():
+        log_formatter = TerminalColorLogFormatter(log_format)
+    else:
+        log_formatter = logging.Formatter(log_format)
+
+    log_handler = logging.StreamHandler(stream=sys.stdout)
+    log_handler.setFormatter(log_formatter)
+    log_handler.addFilter(ProductLogFilter())
+    logging.basicConfig(level=(logging.DEBUG if args.verbose else logging.INFO), handlers=[log_handler])
     install_playwright()
 
     products_dir = Path(args.product_dir)


### PR DESCRIPTION
Pick the log formatter based on the environment:
- GitHub Actions or interactive terminal: color log lines with ANSI escape codes.
- Otherwise (piped/redirected output): plain text, no escape codes.

Also wait for network idle when fetching the Atlassian EOL page.
