### PR TITLE
Shuffle products before processing

### DIFF
--- a/update-release-data.py
+++ b/update-release-data.py
@@ -3,6 +3,7 @@ import importlib
 import json
 import logging
 import os
+import random
 import subprocess
 import sys
 import threading
@@ -280,6 +281,9 @@ if __name__ == "__main__":
 
     products_dir = Path(args.product_dir)
     products_list = list_products(products_dir, args.product)
+    # Shuffle so the concurrent workers hit external sites in a different order on each run, instead of a
+    # predictable alphabetical pattern, and so no product is systematically favored/starved.
+    random.shuffle(products_list)
 
     try:
         with GitHubStepSummary() as step_summary:


### PR DESCRIPTION
Products were previously processed in a fixed alphabetical order (from list_products' sorted glob), meaning every run hit external release-scraping endpoints in the exact same sequence, and the same products always started first among the worker pool.

Shuffle the product list right before processing so:
- external sites see a less predictable per-run request pattern (harder to fingerprint/rate-limit consistently)
- no product is systematically favored (always starts first) or starved (always processed last, e.g. if a run gets cut short)

This has no effect on commit message/summary ordering, since `get_updated_products()` and `generate_commit_message()` still rely on git diff and dict insertion order derived from the sorted list of changed files, independent of processing order.