### PR TITLE
[version_table] Skip rows with an unparseable date

### DIFF
--- a/src/version_table.py
+++ b/src/version_table.py
@@ -86,7 +86,12 @@ def update(_product: ProductFrontmatter, config: AutoConfig) -> None:
                         continue
 
                     version_name = config.render(version_match)
-                    version_date = dates.parse__datetime_or_date_or_month_year_date(cells[version_date_index])
+                    try:
+                        version_date = dates.parse__datetime_or_date_or_month_year_date(cells[version_date_index])
+                    except ValueError as e:
+                        logging.info(f"skipping row {cells}: {e}")
+                        continue
+
                     product_data.declare_version(version_name, version_date)
 
             except ValueError as e:

--- a/src/version_table.py
+++ b/src/version_table.py
@@ -89,7 +89,7 @@ def update(_product: ProductFrontmatter, config: AutoConfig) -> None:
                     try:
                         version_date = dates.parse__datetime_or_date_or_month_year_date(cells[version_date_index])
                     except ValueError as e:
-                        logging.info(f"skipping row {cells}: {e}")
+                        logging.warning(f"skipping row {cells}: {e}")
                         continue
 
                     product_data.declare_version(version_name, version_date)


### PR DESCRIPTION
In `version_table.py`, the `ValueError` raised when a date cannot be parsed is caught outside the loop
over the table's rows. A single unparseable date therefore stops the processing of the whole table, and
every version listed below the offending row is silently lost — the run still reports `success=True`.

This changes the date parsing to skip the offending row and continue, which is what `release_table.py`
already does for cells that do not match their field's regex.

## Effect

Ran `update-release-data.py` for all products using `version_table`, before and after the change:

| Product | versions before | versions after | difference |
|---|---|---|---|
| apache-hop | 4 | 4 | |
| artifactory | 496 | **497** | `+ 7.24.7` |
| big-ip | 113 | 113 | |
| red-hat-jboss-eap | 130 | 130 | |
| red-hat-satellite | 198 | 198 | |
| rocky-linux | 18 | 18 | |
| vinyl-cache | 3 | 3 | |

No product loses a version, which is expected: the change only adds a path where an exception used to
abort the table.

Artifactory is a real case of the bug. Its table has a typo in the release date of version 7.24.6, and
that truncated the table right before the next version:

```
INFO [artifactory]: skipping row ['7.24.6', '05-Sept_2021']: '05-Sept_2021' could not be parsed as a date
```

## Context

I hit this while adding OCI Kubernetes Engine (endoflife-date/endoflife.date#10768). The OKE release
calendar annotates some release dates, such as `2025-10-07 (See Notes)`, and that cell truncated the
table after the three most recent minor versions. With this change all of them are picked up:

```
before: 1.36.1, 1.35.2, 1.34.2
after:  1.36.1, 1.35.2, 1.34.2, 1.33.10, 1.33.1
```

`ruff` (v0.1.6, as pinned in `.pre-commit-config.yaml`) reports no issue on the changed file.
