### PR TITLE
[Perforce] Add auto-update scripts for Helix Core, Proxy, Broker and Swarm

### DIFF
--- a/src/common/http.py
+++ b/src/common/http.py
@@ -40,12 +40,13 @@ _CACHE_SESSION.mount('https://', _ADAPTER)
 _FUTURES_SESSION = FuturesSession(session=_CACHE_SESSION, max_workers=MAX_WORKERS)
 
 def fetch_urls(urls: list[str], data: any = None, user_agent: str = ENDOFLIFE_BOT_USER_AGENT,
-               timeout: int = 30, _remaining_retries: int = MAX_RETRIES) -> list[Response]:
+               timeout: int = 30, extra_headers: dict[str, str] = None,
+               _remaining_retries: int = MAX_RETRIES) -> list[Response]:
     logging.info(f"Fetching {urls}")
 
     try:
         session = _FUTURES_SESSION
-        headers = {'User-Agent': user_agent}
+        headers = {'User-Agent': user_agent, **(extra_headers or {})}
         start = time.perf_counter()
         futures = [session.get(url, headers=headers, data=data, timeout=timeout, stream=None) for url in urls]
         results = [future.result() for future in as_completed(futures)]
@@ -62,12 +63,12 @@ def fetch_urls(urls: list[str], data: any = None, user_agent: str = ENDOFLIFE_BO
         # We could wait a bit before retrying, but it's not clear if it would help.
         logging.warning(
             f"Got ChunkedEncodingError while fetching {urls} ({e}), retrying (remaining retries = {next_remaining_retries}).")
-        return fetch_urls(urls, data, user_agent, timeout, next_remaining_retries)
+        return fetch_urls(urls, data, user_agent, timeout, extra_headers, next_remaining_retries)
 
 
 def fetch_url(url: str, data: any = None, user_agent: str = ENDOFLIFE_BOT_USER_AGENT,
-              timeout: int = 30) -> Response:
-    return fetch_urls([url], data, user_agent, timeout)[0]
+              timeout: int = 30, extra_headers: dict[str, str] = None) -> Response:
+    return fetch_urls([url], data, user_agent, timeout, extra_headers)[0]
 
 def fetch_html(url: str, data: any = None, user_agent: str = ENDOFLIFE_BOT_USER_AGENT,
                timeout: int = 30, features: str = "html5lib") -> BeautifulSoup:
@@ -75,8 +76,8 @@ def fetch_html(url: str, data: any = None, user_agent: str = ENDOFLIFE_BOT_USER_
     return BeautifulSoup(response.text, features=features)
 
 def fetch_json(url: str, data: any = None, user_agent: str = ENDOFLIFE_BOT_USER_AGENT,
-              timeout: int = 30) -> dict:
-    response = fetch_url(url, data, user_agent, timeout)
+              timeout: int = 30, extra_headers: dict[str, str] = None) -> dict:
+    response = fetch_url(url, data, user_agent, timeout, extra_headers)
     return response.json()
 
 def fetch_yaml(url: str, data: any = None, user_agent: str = ENDOFLIFE_BOT_USER_AGENT,

--- a/src/perforce_lifecycle.py
+++ b/src/perforce_lifecycle.py
@@ -1,0 +1,106 @@
+import logging
+import re
+from datetime import datetime
+
+from bs4 import BeautifulSoup
+
+from src.common import dates, http
+from src.common.endoflife import AutoConfig, ProductFrontmatter
+from src.common.releasedata import ProductData
+
+"""Fetch general availability and end-of-life dates from a Perforce lifecycle article.
+
+The lifecycle articles on portal.perforce.com are a Salesforce Experience Cloud site that renders
+client-side, so a plain request returns nothing but the loading shell. The public knowledge endpoint
+serves the article body without authentication instead:
+
+    https://portal.perforce.com/services/data/v59.0/support/knowledgeArticles/<urlName>
+
+Salesforce rejects that call unless a language is named in an Accept-Language header, and offers no
+query parameter to do it instead, so the request carries one.
+
+Pass the URL as the method value. The article body is in the Information__c layout item and holds
+one table per product, each introduced by a heading such as "P4 Server (P4D)" or "P4 Code Review".
+The `selector` argument names the heading to read, so a single article can feed several products:
+the Helix Core article carries P4D, P4Broker and P4Proxy in one page, with identical dates, since
+they are released as one train.
+
+Perforce documents three milestones. From general availability to End of Maintenance a release gets
+bug fixes and security updates. Between End of Maintenance and End of Maintenance and Support those
+fixes are sold separately while technical support continues normally, and after that support drops
+to basic troubleshooting. eoas is therefore mapped to EOM and eol to EOMS.
+
+Only the release cycles are set here. Patch versions are not in these tables, so they come from
+another method: perforce_relnotes for the server family, docker_hub for Swarm.
+"""
+
+# Cells read "P4D 2025.2", "P4Proxy 2025.2" or "P4 Code Review 2026.3".
+CYCLE_PATTERN = re.compile(r"(\d{4}\.\d+)\s*$")
+
+# Cells read "18-Nov-25", "7-Nov-24" or "02-Apr-25".
+DATE_FORMATS = frozenset(["%d-%b-%y", "%d-%b-%Y"])
+
+HEADING_TAGS = ("h1", "h2", "h3", "h4", "h5", "h6")
+
+ARTICLE_HEADERS = {"Accept-Language": "en-US"}
+
+
+def _find_table(soup: BeautifulSoup, selector: str) -> BeautifulSoup | None:
+    """Return the table introduced by the heading matching the selector."""
+    for heading in soup.find_all(HEADING_TAGS):
+        if heading.get_text(strip=True) == selector:
+            return heading.find_next("table")
+    return None
+
+
+def _parse_date(text: str) -> datetime | None:
+    """Parse a lifecycle date, or return None for the placeholders Perforce uses instead."""
+    if not text:
+        return None
+
+    try:
+        return dates.parse_date(text, DATE_FORMATS)
+    except ValueError:
+        # Cells such as "Current Version (under maintenance)" stand in for a date that has not been
+        # decided yet, and are left to the product file.
+        logging.info(f"ignoring '{text}': not a date")
+        return None
+
+
+def update(_product: ProductFrontmatter, config: AutoConfig) -> None:
+    selector = config.data.get("selector")
+    if not selector:
+        message = f"{config} is missing the selector argument naming the table to read"
+        raise ValueError(message)
+
+    article = http.fetch_json(config.url, extra_headers=ARTICLE_HEADERS)
+    body = next((item["value"] for item in article["layoutItems"] if item["name"] == "Information__c"), None)
+    if not body:
+        message = f"{config} returned an article with no body"
+        raise ValueError(message)
+
+    table = _find_table(BeautifulSoup(body, features="html5lib"), selector)
+    if not table:
+        message = f"{config} has no table under a '{selector}' heading"
+        raise ValueError(message)
+
+    with ProductData(config.product) as product_data:
+        for row in table.find_all("tr"):
+            cells = [cell.get_text(strip=True) for cell in row.find_all("td")]
+            if len(cells) < 2:
+                continue
+
+            cycle_match = CYCLE_PATTERN.search(cells[0])
+            if not cycle_match:
+                continue  # The header row, which names the columns rather than a version.
+
+            release = product_data.get_release(cycle_match.group(1))
+
+            if general_availability := _parse_date(cells[1]):
+                release.set_release_date(general_availability)
+
+            if end_of_maintenance := _parse_date(cells[2] if len(cells) > 2 else ""):
+                release.set_eoas(end_of_maintenance)
+
+            if end_of_support := _parse_date(cells[3] if len(cells) > 3 else ""):
+                release.set_eol(end_of_support)

--- a/src/perforce_relnotes.py
+++ b/src/perforce_relnotes.py
@@ -1,0 +1,53 @@
+import logging
+import re
+
+from src.common import dates, http
+from src.common.endoflife import AutoConfig, ProductFrontmatter
+from src.common.releasedata import ProductData
+
+"""Fetch Perforce patch versions from the plain text release notes.
+
+Perforce publishes one release notes file covering p4d, p4, p4p and p4broker together, because they
+are built and shipped as one train:
+
+    https://help.perforce.com/helix-core/release-notes/current/relnotes.txt
+
+Every release and patch is introduced by a heading carrying the full version and the date:
+
+    Bugs fixed in 2025.2 Patch 2 (2025.2/2907753) (2026/03/09)
+
+Versions are declared as Perforce writes them, release and change level separated by a slash, which
+is what `p4d -V` reports and what the patch is referred to by.
+
+Release cycle dates are left to perforce_lifecycle. The two disagree on purpose: the date in a
+heading is when the build was cut, while the general availability Perforce anchors its end-of-life
+dates to falls about a week later.
+
+Note that the file only keeps the recent history. Headings for the first release of a cycle drop out
+once it is old enough, so the earliest heading for a cycle is not necessarily its first release.
+
+The `regex` and `regex_exclude` arguments are not honoured. Only stable releases reach this file, so
+there is nothing to filter, and the default version regex would in any case reject every version
+here because of the slash between the release and the change level.
+"""
+
+RELEASE_PATTERN = re.compile(
+    r"^(?:Bugs fixed|Major new functionality|Minor new functionality|New functionality)"
+    r" in \d{4}\.\d+(?: Patch \d+)?\s*"
+    r"\((?P<version>\d{4}\.\d+/\d+)\)\s*"
+    r"\((?P<date>\d{4}/\d{2}/\d{2})\)",
+    re.MULTILINE)
+
+
+def update(_product: ProductFrontmatter, config: AutoConfig) -> None:
+    relnotes = http.fetch_url(config.url).text
+
+    with ProductData(config.product) as product_data:
+        for match in RELEASE_PATTERN.finditer(relnotes):
+            product_data.declare_version(match.group("version"), dates.parse_date(match.group("date")))
+
+        if not product_data.versions:
+            message = f"{config} found no version in the release notes"
+            raise ValueError(message)
+
+        logging.info(f"found {len(product_data.versions)} versions in the release notes")


### PR DESCRIPTION
## Summary

Adds two scripts covering the four Perforce products proposed in endoflife-date/endoflife.date#10959. That PR can land in either order; the pages do not depend on these.

| Script | What it sets |
| --- | --- |
| `perforce_lifecycle` | `releaseDate`, `eoas` and `eol` per cycle, from a Perforce lifecycle article |
| `perforce_relnotes` | patch versions, from the plain text release notes |

## `perforce_lifecycle`

The lifecycle articles on portal.perforce.com are a Salesforce Experience Cloud site that renders client-side, so a plain request returns nothing but the loading shell. The public knowledge endpoint serves the article body without authentication instead:

```
https://portal.perforce.com/services/data/v59.0/support/knowledgeArticles/<urlName>
```

An article holds one table per product, each introduced by a heading. The `selector` argument names the heading to read, following the same idea as `atlassian_eol`, so one article can feed several products — the Helix Core article carries P4D, P4Proxy and P4Broker in a single page with identical dates, since they are released as one train.

Perforce documents three milestones: **GA**, **End of Maintenance** and **End of Maintenance and Support**. The [EOL Reference Table](https://portal.perforce.com/s/article/Perforce-End-of-Life-EOL-Reference-Table) is what pins the mapping down — between EOM and EOMS technical support is still full and only the fixes become a paid extra, so `eoas` is EOM and `eol` is EOMS.

Cells sometimes read `Current Version (under maintenance)` instead of a date. Those are skipped and left to the product file.

## `perforce_relnotes`

Perforce publishes one release notes file covering p4d, p4, p4p and p4broker together:

```
https://help.perforce.com/helix-core/release-notes/current/relnotes.txt
```

Every release and patch is introduced by a heading carrying the full version and the date, for example `Bugs fixed in 2025.2 Patch 2 (2025.2/2907753) (2026/03/09)`. Versions are declared as Perforce writes them, release and change level separated by a slash, which is what `p4d -V` reports.

Cycle release dates are deliberately left to `perforce_lifecycle`: the date in a heading is when the build was cut, while the general availability that the end-of-life dates are anchored to falls about a week later.

`regex` and `regex_exclude` are not honoured here. Only stable releases reach this file, and the default version regex would in any case reject every version because of the slash.

## One change to shared code

Salesforce rejects the knowledge endpoint unless a language is named in an `Accept-Language` header, and offers no query parameter to do it instead:

```json
[{"errorCode":"MISSING_ARGUMENT","message":"Language has to be specified in HTTP header."}]
```

Rather than bypass `http.py` and lose its caching and retries, `fetch_urls`, `fetch_url` and `fetch_json` now take an optional `extra_headers` argument, merged over the `User-Agent`. The parameter is added before the private `_remaining_retries`, and no caller anywhere in the repository passes that positionally, so existing callers are unaffected. Happy to split this out if you would rather review it separately.

## Notes

Swarm is covered by `perforce_lifecycle` only. `docker_hub: perforce/helix-swarm` was tried for its versions and rejected: the images for 2024.2 through 2024.5 were all pushed on 2025-01-08 in one batch, so it would have replaced four accurate release dates with that.

## Test plan

Run against the four product pages from endoflife-date/endoflife.date#10959, with:

```yaml
# helix-core, and the same with a P4 Proxy (P4P) / P4 Broker (P4Broker) selector
auto:
  methods:
    - perforce_lifecycle: https://portal.perforce.com/services/data/v59.0/support/knowledgeArticles/Helix-Core-Maintenance-Lifecycle-Helix-Core-Server-P4D
      selector: P4 Server (P4D)
    - perforce_relnotes: https://help.perforce.com/helix-core/release-notes/current/relnotes.txt

# helix-swarm
auto:
  methods:
    - perforce_lifecycle: https://portal.perforce.com/services/data/v59.0/support/knowledgeArticles/Helix-Swarm-Maintenance-Lifecycle
      selector: P4 Code Review
```

- [x] `pre-commit run` passes on all three files, ruff included
- [x] A cold run yields 10 cycles and 65 versions for each of Helix Core, Proxy and Broker, and 19 cycles for Swarm
- [x] `update-product-data.py` afterwards rewrites nothing in any of the four pages — every date matches what is proposed there
- [x] 2026.1, which Perforce has not dated yet, is left untouched rather than emptied
- [x] A cycle that only the lifecycle article knows about is not written into the page as an incomplete release